### PR TITLE
Don't warn for units on hsl(0, 0%, 0%)

### DIFF
--- a/EditorExtensions/ErrorTags/Providers/ZeroUnitErrorTagProvider.cs
+++ b/EditorExtensions/ErrorTags/Providers/ZeroUnitErrorTagProvider.cs
@@ -22,6 +22,14 @@ namespace MadsKristensen.EditorExtensions
             if (unit == null || context == null)
                 return ItemCheckResult.Continue;
 
+            // The 2nd and 3rd arguments to hsl() require units even when zero
+            var function = unit.Parent.Parent as FunctionColor;
+            if (function != null && function.FunctionName.Text.StartsWith("hsl", StringComparison.OrdinalIgnoreCase)) {
+                var arg = unit.Parent as FunctionArgument;
+                if (arg != function.Arguments[0])
+                    return ItemCheckResult.Continue;
+            }
+
             if (number.Number.Text == "0" && unit.UnitType != UnitType.Unknown && unit.UnitType != UnitType.Time)
             {
                 string message = string.Format(Resources.BestPracticeZeroUnit, unit.UnitToken.Text);


### PR DESCRIPTION
Saturation and luminosity are incorrectly reported as having optional zero units:

``` css
color: hsl(0,0%,0%);
```

This gives "Best Practice: Don't specify the unit type (%) when the value is zero" twice; removing the % creates invalid CSS (and isn't even recognized by your neat color features)

This may not be the most elegant way to add this check.
