### PR TITLE
Small Markdown Fixes

### DIFF
--- a/EditorExtensions/Classifications/Markdown/MarkdownClassifier.cs
+++ b/EditorExtensions/Classifications/Markdown/MarkdownClassifier.cs
@@ -37,7 +37,7 @@ namespace MadsKristensen.EditorExtensions
         private static readonly Regex _reItalic = new Regex(@"(?<Value>((?<!\*)\*(?!\*)|(?<!_)_(?!_))[^\s].+?[^\s]\1\b)");
 
         // A multi-line fenced code block starting in a quote should all count as part of the quote
-        private static readonly Regex _reQuote = new Regex(@"(?=(?:" + lineBegin + fencedCodeBlock + @"[\s\S]+)*) {0,3}(> {0,3})+(?<Value>" + fencedCodeBlock + "|(?!(> {0,3})*```).+$)", RegexOptions.Multiline);
+        private static readonly Regex _reQuote = new Regex(lineBegin + @"( {0,3}>)+(?<Value> {0,3}(" + fencedCodeBlock + @"|(?!(> {0,3})*```)).+$)", RegexOptions.Multiline);
 
         private static readonly Regex _reHeader = new Regex(lineBegin + @"(?<Value>([#]{1,6})[^#\r\n]+(\1(?!#))?)", RegexOptions.Multiline);
         private static readonly Regex _reCode = new Regex(

--- a/EditorExtensions/Classifications/Markdown/Sample.md
+++ b/EditorExtensions/Classifications/Markdown/Sample.md
@@ -8,6 +8,8 @@ Here is code with underscores: `abc + _something_ + def`, ending later with `_pr
 
 However, single ` characters should not be affected, even if there is **bold** afterwards.  
 
+This is > not a quote
+
 `code`, then _italic_, or **bold**.
 Even  **_bold/italic_** or _**italic/bold**_
 


### PR DESCRIPTION
Indented code blocks inside quotes now start at four spaces.

I also changed quote highlighting to include the whitespace after the final `>`.  
This makes highlighted code blocks within quotes line up with the rest of the quotes, as opposed to starting after the third space.
