### PR TITLE
Speed Typing: Don't add braces in LESS comments

### DIFF
--- a/EditorExtensions/Commands/Css/SpeedTyping.cs
+++ b/EditorExtensions/Commands/Css/SpeedTyping.cs
@@ -253,6 +253,15 @@ namespace MadsKristensen.EditorExtensions
             if (text.IndexOf('{') > -1)
                 return false;
 
+            if (line.Snapshot.ContentType.DisplayName == "LESS")
+            {
+                var commentStart = text.IndexOf("//");
+                if (commentStart > position)
+                    return false;
+                if (commentStart > 0)
+                    text = text.Remove(commentStart);
+            }
+
             if (text.Trim().EndsWith(",", StringComparison.Ordinal))
                 return false;
 


### PR DESCRIPTION
Pressing Enter in a LESS comment at the end of a multi-line selector will no longer break the selector.
