### PR TITLE
Fix input type handling in advanced LESS scenarios

### DIFF
--- a/EditorExtensions/Completion/CSS/ContextProviders/InputTypeContextCompletionProvider.cs
+++ b/EditorExtensions/Completion/CSS/ContextProviders/InputTypeContextCompletionProvider.cs
@@ -30,8 +30,10 @@ namespace MadsKristensen.EditorExtensions.Completion.ContextProviders
             // Test cases
             //
             // The following should be ignored
-            //   a[type=""] {}          // ignore: not "input" element
             //   input[wibble=""] {}    // ignore: not "type" attribute
+            //   a[type=""] {}          // ignore: not "input" element. 
+            //                          // This case isn't handled correctly as it is an edge case and hugely complicates the handling of LESS scenarios such as 
+            //                          // input { &.myclass {  &[type=""] { } } }
             //
             // The following should be handled
             //   input[type=""] {}
@@ -40,15 +42,10 @@ namespace MadsKristensen.EditorExtensions.Completion.ContextProviders
             //   foo input[type=""] {}
             //   input[type=""] foo {}
             //   input[foo="bar"][type=""] {}
-
+            //   input.myclass[type=""] {}
 
             var attributeSelector = (AttributeSelector)item;
             if (attributeSelector.AttributeName.Text != "type")
-            {
-                return null;
-            }
-            var parent = attributeSelector.Parent as SimpleSelector;
-            if (parent == null || parent.Name.Text != "input")
             {
                 return null;
             }


### PR DESCRIPTION
 Removed element name checking as per discussion with SLaks as it doesn't add much value and breaks some LESS scenarios
 (Comment in https://github.com/madskristensen/WebEssentials2013/pull/21)
