### PR TITLE
Refactor HTML completions

### DIFF
--- a/EditorExtensions/Completion/HTML/AppleLinkCompletion.cs
+++ b/EditorExtensions/Completion/HTML/AppleLinkCompletion.cs
@@ -8,29 +8,13 @@ namespace MadsKristensen.EditorExtensions
 {
     [HtmlCompletionProvider(CompletionType.Values, "link", "sizes")]
     [ContentType(HtmlContentTypeDefinition.HtmlContentType)]
-    public class AppleLinkCompletion : IHtmlCompletionListProvider
+    public class AppleLinkCompletion : StaticListCompletion
     {
-        public CompletionType CompletionType
-        {
-            get { return CompletionType.Values; }
-        }
-        
-        public IList<HtmlCompletion> GetEntries(HtmlCompletionContext context)
-        {
-            var result = new List<HtmlCompletion>();
-            var attr = context.Element.GetAttribute("rel");
-            
-            if (attr == null)
-                return result;
-
-            if (attr.Value.Equals("apple-touch-icon", StringComparison.OrdinalIgnoreCase))
+        protected override string KeyProperty { get { return "rel"; } }
+        public AppleLinkCompletion()
+            : base(new Dictionary<string, IList<HtmlCompletion>>(StringComparer.OrdinalIgnoreCase)
             {
-                result.Add(new SimpleHtmlCompletion("72x72"));
-                result.Add(new SimpleHtmlCompletion("114x114"));
-                result.Add(new SimpleHtmlCompletion("144x144"));
-            }
-
-            return result;
-        }
+                { "apple-touch-icon", Values("72x72", "114x114", "144x144") }
+            }) { }
     }
 }

--- a/EditorExtensions/Completion/HTML/AppleMetaCompletion.cs
+++ b/EditorExtensions/Completion/HTML/AppleMetaCompletion.cs
@@ -8,39 +8,15 @@ namespace MadsKristensen.EditorExtensions
 {
     [HtmlCompletionProvider(CompletionType.Values, "meta", "content")]
     [ContentType(HtmlContentTypeDefinition.HtmlContentType)]
-    public class AppleMetaCompletion : IHtmlCompletionListProvider
+    public class AppleMetaCompletion : StaticListCompletion
     {
-        public CompletionType CompletionType
-        {
-            get { return CompletionType.Values; }
-        }
-        
-        public IList<HtmlCompletion> GetEntries(HtmlCompletionContext context)
-        {
-            var result = new List<HtmlCompletion>();
-            var attr = context.Element.GetAttribute("name");
-            
-            if (attr == null)
-                return result;
-
-            if (attr.Value.Equals("apple-mobile-web-app-capable", StringComparison.OrdinalIgnoreCase))
+        protected override string KeyProperty { get { return "name"; } }
+        public AppleMetaCompletion()
+            : base(new Dictionary<string, IList<HtmlCompletion>>(StringComparer.OrdinalIgnoreCase)
             {
-                result.Add(new SimpleHtmlCompletion("yes"));
-                result.Add(new SimpleHtmlCompletion("no"));
-            }
-            else if (attr.Value.Equals("format-detection", StringComparison.OrdinalIgnoreCase))
-            {
-                result.Add(new SimpleHtmlCompletion("telephone=yes"));
-                result.Add(new SimpleHtmlCompletion("telephone=no"));
-            }
-            else if (attr.Value.Equals("apple-mobile-web-app-status-bar-style", StringComparison.OrdinalIgnoreCase))
-            {
-                result.Add(new SimpleHtmlCompletion("default"));
-                result.Add(new SimpleHtmlCompletion("black"));
-                result.Add(new SimpleHtmlCompletion("black-translucent"));
-            }
-
-            return result;
-        }
+                { "apple-mobile-web-app-capable",           Values("yes", "no") },
+                { "format-detection",                       Values("telephone=yes", "telephone=no") },
+                { "apple-mobile-web-app-status-bar-style",  Values("default", "black", "black-translucent") }
+            }) { }
     }
 }

--- a/EditorExtensions/Completion/HTML/HtmlDataListCompletion.cs
+++ b/EditorExtensions/Completion/HTML/HtmlDataListCompletion.cs
@@ -3,6 +3,7 @@ using Microsoft.Html.Editor.Intellisense;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.Editor;
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 namespace MadsKristensen.EditorExtensions
@@ -18,27 +19,19 @@ namespace MadsKristensen.EditorExtensions
 
         public IList<HtmlCompletion> GetEntries(HtmlCompletionContext context)
         {
-            var result = new List<HtmlCompletion>();
-            var list = new List<string>();
+            var list = new HashSet<string>();
 
             context.Document.HtmlEditorTree.RootNode.Accept(this, list);
 
-            foreach (var item in list)
-            {
-                result.Add(new SimpleHtmlCompletion(item));
-            }
-
-            return result;
+            return list.Select(s => new SimpleHtmlCompletion(s)).ToList<HtmlCompletion>();
         }
 
         public bool Visit(ElementNode element, object parameter)
         {
             if (element.Name.Equals("datalist", StringComparison.OrdinalIgnoreCase))
             {
-                var list = (List<string>)parameter;
-
-                if (!list.Contains(element.Id))
-                    list.Add(element.Id);
+                var list = (HashSet<string>)parameter;
+                list.Add(element.Id);
             }
 
             return true;

--- a/EditorExtensions/Completion/HTML/HtmlLabelForAttributeCompletion.cs
+++ b/EditorExtensions/Completion/HTML/HtmlLabelForAttributeCompletion.cs
@@ -4,6 +4,7 @@ using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.Editor;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MadsKristensen.EditorExtensions
 {
@@ -19,29 +20,22 @@ namespace MadsKristensen.EditorExtensions
 
         public IList<HtmlCompletion> GetEntries(HtmlCompletionContext context)
         {
-            var result = new List<HtmlCompletion>();
-            var list = new List<string>();
+            var list = new HashSet<string>();
             var glyph = GlyphService.GetGlyph(StandardGlyphGroup.GlyphGroupVariable, StandardGlyphItem.GlyphItemPublic);
 
             context.Document.HtmlEditorTree.RootNode.Accept(this, list);
 
-            foreach (var item in list)
-            {
-                var completion = new HtmlCompletion(item, item, item, glyph, HtmlIconAutomationText.AttributeIconText);
-                result.Add(completion);
-            }
-
-            return result;
+            return list.Select(s => new HtmlCompletion(s, s, s, glyph, HtmlIconAutomationText.AttributeIconText)).ToList();
         }
 
         public bool Visit(ElementNode element, object parameter)
         {
             if (_inputTypes.Contains(element.Name.ToLowerInvariant()))
             {
-                var list = (List<string>)parameter;
+                var list = (HashSet<string>)parameter;
                 var id = element.GetAttribute("id");
 
-                if (id != null && !list.Contains(id.Value))
+                if (id != null)
                     list.Add(id.Value);
             }
 

--- a/EditorExtensions/Completion/HTML/MetaHttpEquivCompletion.cs
+++ b/EditorExtensions/Completion/HTML/MetaHttpEquivCompletion.cs
@@ -4,62 +4,25 @@ using Microsoft.Html.Schemas.Model;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.Editor;
 using System;
+using System.Linq;
 using System.Collections.Generic;
 
 namespace MadsKristensen.EditorExtensions
 {
     [HtmlCompletionProvider(CompletionType.Values, "meta", "content")]
     [ContentType(HtmlContentTypeDefinition.HtmlContentType)]
-    public class MetaHttpEquivCompletion : IHtmlCompletionListProvider
+    public class MetaHttpEquivCompletion : StaticListCompletion
     {
-        public CompletionType CompletionType
-        {
-            get { return CompletionType.Values; }
-        }
-
-        public IList<HtmlCompletion> GetEntries(HtmlCompletionContext context)
-        {
-            var result = new List<HtmlCompletion>();
-            var attr = context.Element.GetAttribute("http-equiv");
-
-            if (attr == null)
-                return result;
-
-            if (attr.Value.Equals("X-UA-Compatible", StringComparison.OrdinalIgnoreCase))
+        protected override string KeyProperty { get { return "http-equiv"; } }
+        public MetaHttpEquivCompletion()
+            : base(new Dictionary<string, IList<HtmlCompletion>>(StringComparer.OrdinalIgnoreCase)
             {
-                result.Add(new SimpleHtmlCompletion("IE=edge", "Comma separate multiple value if needed"));
-                result.Add(new SimpleHtmlCompletion("IE=7", "Comma separate multiple value if needed"));
-                result.Add(new SimpleHtmlCompletion("IE=8", "Comma separate multiple value if needed"));
-                result.Add(new SimpleHtmlCompletion("IE=9", "Comma separate multiple value if needed"));
-                result.Add(new SimpleHtmlCompletion("FF=3", "Comma separate multiple value if needed"));
-            }
-            else if (attr.Value.Equals("content-type", StringComparison.OrdinalIgnoreCase))
-            {
-                foreach (string value in GetAttributeValue("meta", "charset"))
-                {
-                    result.Add(new SimpleHtmlCompletion("text/html; charset=" + value));
-                }
-            }
-            else if (attr.Value.Equals("refresh", StringComparison.OrdinalIgnoreCase))
-            {
-                result.Add(new SimpleHtmlCompletion("3"));
-                result.Add(new SimpleHtmlCompletion("3; url=http://example.com"));
-            }
-            else if (attr.Value.Equals("content-language", StringComparison.OrdinalIgnoreCase))
-            {
-                foreach (string value in GetAttributeValue("html", "lang"))
-                {
-                    result.Add(new SimpleHtmlCompletion(value));
-                }
-            }
-            else if (attr.Value.Equals("set-cookie", StringComparison.OrdinalIgnoreCase))
-            {
-                result.Add(new SimpleHtmlCompletion("name=value; expires=Fri, 30 Dec 2019 12:00:00 GMT; path=/"));
-                result.Add(new SimpleHtmlCompletion("name=value; expires=Fri, 30 Dec 2019 12:00:00 GMT; path=http://example.com"));
-            }
-
-            return result;
-        }
+                { "X-UA-Compatible",    Values("IE=edge", "IE=7", "IE=8", "IE=9", "FF=3").WithDescription("Separate multiple values with commas if needed") },
+                { "Content-Type",       Values(GetAttributeValue("meta", "charset").Select(c => "text/html; charset=" + c)) },
+                { "refresh",            Values("3", "3; url=http://example.com") },
+                { "Content-Type",       Values(GetAttributeValue("html", "lang")) },
+                { "Set-Cookie",         Values("name=value; expires=Fri, 30 Dec 2019 12:00:00 GMT; path=/", "name=value; expires=Fri, 30 Dec 2019 12:00:00 GMT; path=http://example.com") },
+            }) { }
 
         public static IEnumerable<string> GetAttributeValue(string elementName, string attributeName)
         {

--- a/EditorExtensions/Completion/HTML/MiscMetaCompletion.cs
+++ b/EditorExtensions/Completion/HTML/MiscMetaCompletion.cs
@@ -3,42 +3,20 @@ using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.Editor;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace MadsKristensen.EditorExtensions
 {
     [HtmlCompletionProvider(CompletionType.Values, "meta", "content")]
     [ContentType(HtmlContentTypeDefinition.HtmlContentType)]
-    public class MiscMetaCompletion : IHtmlCompletionListProvider
+    public class MiscMetaCompletion : StaticListCompletion
     {
-        public CompletionType CompletionType
-        {
-            get { return CompletionType.Values; }
-        }
-        
-        public IList<HtmlCompletion> GetEntries(HtmlCompletionContext context)
-        {
-            var result = new List<HtmlCompletion>();
-            var attr = context.Element.GetAttribute("name");
-            
-            if (attr == null)
-                return result;
-
-            if (attr.Value.Equals("generator", StringComparison.OrdinalIgnoreCase))
+        protected override string KeyProperty { get { return "name"; } }
+        public MiscMetaCompletion()
+            : base(new Dictionary<string, IList<HtmlCompletion>>(StringComparer.OrdinalIgnoreCase)
             {
-                result.Add(new SimpleHtmlCompletion("Visual Studio"));
-            }
-            if (attr.Value.Equals("robots", StringComparison.OrdinalIgnoreCase))
-            {
-                result.Add(new SimpleHtmlCompletion("index"));
-                result.Add(new SimpleHtmlCompletion("noindex"));
-                result.Add(new SimpleHtmlCompletion("follow"));
-                result.Add(new SimpleHtmlCompletion("nofollow"));
-                result.Add(new SimpleHtmlCompletion("noindex, nofollow"));
-                result.Add(new SimpleHtmlCompletion("noindex, follow"));
-                result.Add(new SimpleHtmlCompletion("index, nofollow"));
-            }
-
-            return result;
-        }
+                { "generator",  Values("Visual Studio") },
+                { "robots",     Values("index", "noindex", "follow", "nofollow", "noindex, nofollow", "noindex, follow", "index, nofollow") }
+          }) { }
     }
 }

--- a/EditorExtensions/Completion/HTML/OpenGraphTypeCompletion.cs
+++ b/EditorExtensions/Completion/HTML/OpenGraphTypeCompletion.cs
@@ -4,90 +4,56 @@ using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.Editor;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MadsKristensen.EditorExtensions
 {
     [HtmlCompletionProvider(CompletionType.Values, "meta", "content")]
     [ContentType(HtmlContentTypeDefinition.HtmlContentType)]
-    public class OpenGraphTypeCompletion : IHtmlCompletionListProvider, IHtmlTreeVisitor
+    public class OpenGraphTypeCompletion : StaticListCompletion, IHtmlTreeVisitor
     {
-        public CompletionType CompletionType
-        {
-            get { return CompletionType.Values; }
-        }
+        protected override string KeyProperty { get { return "name"; } }
+        public OpenGraphTypeCompletion()
+            : base(new Dictionary<string, IList<HtmlCompletion>>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "og:type",            Values("article", "book", "music", "music.album", "music.playlist", 
+                                               "music.radio_station", "music.song", "profile", "video",
+                                               "video.episode", "video.movie", "video.movie", "video.other", 
+                                               "video.tv_show", "website") },
+                { "og:audio:type",      Values(MetaHttpEquivCompletion.GetAttributeValue("source", "type").Where(v => v.StartsWith("audio/", StringComparison.OrdinalIgnoreCase))) },
+                { "og:video:type",      Values(MetaHttpEquivCompletion.GetAttributeValue("source", "type").Where(v => v.StartsWith("video/", StringComparison.OrdinalIgnoreCase)).Concat(new[]{"application/x-shockwave-flash"})) },
+                { "apple-mobile-web-app-status-bar-style",  Values("default", "black", "black-translucent") }
+            }) { }
 
         public IList<HtmlCompletion> GetEntries(HtmlCompletionContext context)
         {
-            var result = new List<HtmlCompletion>();
             var attr = context.Element.GetAttribute("property");
 
             if (attr == null)
-                return result;
+                return Empty;
 
-            if (attr.Value.Equals("og:type", StringComparison.OrdinalIgnoreCase))
-            {
-                result.Add(new SimpleHtmlCompletion("article"));
-                result.Add(new SimpleHtmlCompletion("book"));
-                result.Add(new SimpleHtmlCompletion("music"));
-                result.Add(new SimpleHtmlCompletion("music.album"));
-                result.Add(new SimpleHtmlCompletion("music.playlist"));
-                result.Add(new SimpleHtmlCompletion("music.radio_station"));
-                result.Add(new SimpleHtmlCompletion("music.song"));
-                result.Add(new SimpleHtmlCompletion("profile"));
-                result.Add(new SimpleHtmlCompletion("video"));
-                result.Add(new SimpleHtmlCompletion("video.episode"));
-                result.Add(new SimpleHtmlCompletion("video.movie"));
-                result.Add(new SimpleHtmlCompletion("video.movie"));
-                result.Add(new SimpleHtmlCompletion("video.other"));
-                result.Add(new SimpleHtmlCompletion("video.tv_show"));
-                result.Add(new SimpleHtmlCompletion("website"));
-            }
-            if (attr.Value.Equals("og:video:type", StringComparison.OrdinalIgnoreCase))
-            {
-                foreach (string value in MetaHttpEquivCompletion.GetAttributeValue("source", "type"))
-                {
-                    if (value.StartsWith("video/", StringComparison.OrdinalIgnoreCase))
-                        result.Add(new SimpleHtmlCompletion(value));
-                }
-
-                result.Add(new SimpleHtmlCompletion("application/x-shockwave-flash"));
-            }
-            if (attr.Value.Equals("og:audio:type", StringComparison.OrdinalIgnoreCase))
-            {
-                foreach (string value in MetaHttpEquivCompletion.GetAttributeValue("source", "type"))
-                {
-                    if (value.StartsWith("audio/", StringComparison.OrdinalIgnoreCase))
-                        result.Add(new SimpleHtmlCompletion(value));
-                }
-            }
-            else if (attr.Value.Equals("og:site_name", StringComparison.OrdinalIgnoreCase) ||
-                     attr.Value.Equals("og:title", StringComparison.OrdinalIgnoreCase))
+            if (attr.Value.Equals("og:site_name", StringComparison.OrdinalIgnoreCase)
+             || attr.Value.Equals("og:title", StringComparison.OrdinalIgnoreCase))
             {
                 if (context.Element.Parent == null)
-                    return result;
+                    return Empty;
 
-                var list = new List<string>();
-
+                var list = new HashSet<string>();
                 context.Element.Parent.Accept(this, list);
-
-                foreach (var item in list)
-                {
-                    result.Add(new SimpleHtmlCompletion(item));
-                }
+                return Values(list);
             }
 
-            return result;
+            return base.GetEntries(context);
         }
 
         public bool Visit(ElementNode element, object parameter)
         {
             if (element.Name.Equals("title", StringComparison.OrdinalIgnoreCase))
             {
-                var list = (List<string>)parameter;
+                var list = (HashSet<string>)parameter;
 
                 string text = element.GetText(element.InnerRange);
-                if (!list.Contains(text))
-                    list.Add(text);
+                list.Add(text);
             }
 
             return true;

--- a/EditorExtensions/Completion/HTML/StaticListCompletion.cs
+++ b/EditorExtensions/Completion/HTML/StaticListCompletion.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.Html.Editor.Intellisense;
+using Microsoft.VisualStudio.Utilities;
+using Microsoft.Web.Editor;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace MadsKristensen.EditorExtensions
+{
+    public abstract class StaticListCompletion : IHtmlCompletionListProvider
+    {
+        public CompletionType CompletionType
+        {
+            get { return CompletionType.Values; }
+        }
+
+        protected StaticListCompletion(Dictionary<string, IList<HtmlCompletion>> values)
+        {
+            this.values = values;
+        }
+
+        ///<summary>Gets the property that serves as a key to look up completion values against.</summary>
+        protected abstract string KeyProperty { get; }
+
+        protected static readonly ReadOnlyCollection<HtmlCompletion> Empty = new ReadOnlyCollection<HtmlCompletion>(new HtmlCompletion[0]);
+
+        ///<summary>Creates a collection of HTML completion items from a list of static values.</summary>
+        protected static ReadOnlyCollection<HtmlCompletion> Values(params string[] values)
+        {
+            return new ReadOnlyCollection<HtmlCompletion>(Array.ConvertAll(values, s => new SimpleHtmlCompletion(s)));
+        }
+        ///<summary>Creates a collection of HTML completion items from a list of static values.</summary>
+        protected static ReadOnlyCollection<HtmlCompletion> Values(IEnumerable<string> values)
+        {
+            return new ReadOnlyCollection<HtmlCompletion>(values.Select(s => new SimpleHtmlCompletion(s)).ToList<HtmlCompletion>());
+        }
+
+        readonly IReadOnlyDictionary<string, IList<HtmlCompletion>> values;
+        public IList<HtmlCompletion> GetEntries(HtmlCompletionContext context)
+        {
+            IList<HtmlCompletion> result;
+            var attr = context.Element.GetAttribute(KeyProperty);
+
+            values.TryGetValue(attr.Value, out result);
+            return result ?? Empty;
+        }
+    }
+}

--- a/EditorExtensions/Completion/HTML/TwitterCardCompletion.cs
+++ b/EditorExtensions/Completion/HTML/TwitterCardCompletion.cs
@@ -8,33 +8,13 @@ namespace MadsKristensen.EditorExtensions
 {
     [HtmlCompletionProvider(CompletionType.Values, "meta", "content")]
     [ContentType(HtmlContentTypeDefinition.HtmlContentType)]
-    public class TwitterCardCompletion : IHtmlCompletionListProvider
+    public class TwitterCardCompletion : StaticListCompletion
     {
-        public CompletionType CompletionType
-        {
-            get { return CompletionType.Values; }
-        }
-        
-        public IList<HtmlCompletion> GetEntries(HtmlCompletionContext context)
-        {
-            var result = new List<HtmlCompletion>();
-            var attr = context.Element.GetAttribute("name");
-
-            if (attr == null)
-                return result;
-
-            if (attr.Value.Equals("twitter:card", StringComparison.OrdinalIgnoreCase))
+        protected override string KeyProperty { get { return "name"; } }
+        public TwitterCardCompletion()
+            : base(new Dictionary<string, IList<HtmlCompletion>>(StringComparer.OrdinalIgnoreCase)
             {
-                result.Add(new SimpleHtmlCompletion("app"));
-                result.Add(new SimpleHtmlCompletion("gallery"));
-                result.Add(new SimpleHtmlCompletion("photo"));
-                result.Add(new SimpleHtmlCompletion("player"));
-                result.Add(new SimpleHtmlCompletion("product"));
-                result.Add(new SimpleHtmlCompletion("summary"));
-                result.Add(new SimpleHtmlCompletion("summary_large-image"));
-            }
-
-            return result;
-        }
+                { "twitter:card",  Values("app", "gallery", "photo", "player", "product", "summary", "summary_large-image") }
+            }) { }
     }
 }

--- a/EditorExtensions/Completion/HTML/ViewportCompletion.cs
+++ b/EditorExtensions/Completion/HTML/ViewportCompletion.cs
@@ -8,27 +8,18 @@ namespace MadsKristensen.EditorExtensions
 {
     [HtmlCompletionProvider(CompletionType.Values, "meta", "content")]
     [ContentType(HtmlContentTypeDefinition.HtmlContentType)]
-    public class ViewportCompletion : IHtmlCompletionListProvider
+    public class ViewportCompletion : StaticListCompletion
     {
-        public CompletionType CompletionType
-        {
-            get { return CompletionType.Values; }
-        }
-        
-        public IList<HtmlCompletion> GetEntries(HtmlCompletionContext context)
-        {
-            var result = new List<HtmlCompletion>();
-            var attr = context.Element.GetAttribute("name");
-
-            if (attr != null && attr.Value.Equals("viewport", StringComparison.OrdinalIgnoreCase))
+        protected override string KeyProperty { get { return "name"; } }
+        public ViewportCompletion()
+            : base(new Dictionary<string, IList<HtmlCompletion>>(StringComparer.OrdinalIgnoreCase)
             {
-                result.Add(new SimpleHtmlCompletion("width=device-width, initial-scale=1.0", "Example viewport value"));
-                result.Add(new SimpleHtmlCompletion("width=device-width, initial-scale=1.0, user-scalable=no", "Example viewport value"));
-                result.Add(new SimpleHtmlCompletion("width=device-width, initial-scale=1.0, maximum-scale=1", "Example viewport value"));
-                result.Add(new SimpleHtmlCompletion("width=device-width, initial-scale=1.0, minimum-scale=1", "Example viewport value"));
-            }
-
-            return result;
-        }
+                { "viewport", Values(
+                    "width=device-width, initial-scale=1.0", 
+                    "width=device-width, initial-scale=1.0, user-scalable=no", 
+                    "width=device-width, initial-scale=1.0, maximum-scale=1", 
+                    "width=device-width, initial-scale=1.0, minimum-scale=1"
+                ).WithDescription("Sample viewport value") }
+            }) { }
     }
 }

--- a/EditorExtensions/ExtensionMethods/IVsExtensions.cs
+++ b/EditorExtensions/ExtensionMethods/IVsExtensions.cs
@@ -1,4 +1,6 @@
-﻿using EnvDTE;
+﻿using System.Collections.Generic;
+using EnvDTE;
+using System;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -33,6 +35,27 @@ namespace MadsKristensen.EditorExtensions
             {
                 return false;
             }
+        }
+
+        ///<summary>Sets the Description property for a set of completion items.</summary>
+        ///<remarks>This method is used to help build completion lists without repetition.</remarks>
+        public static IList<T> WithDescription<T>(this IList<T> completions, string tooltip) where T : Microsoft.VisualStudio.Language.Intellisense.Completion
+        {
+            foreach (var c in completions)
+            {
+                c.Description = tooltip;
+            }
+            return completions;
+        }
+        ///<summary>Sets the Description property for a set of completion items.</summary>
+        ///<remarks>This method is used to help build completion lists without repetition.</remarks>
+        public static IList<T> WithDescription<T>(this IList<T> completions, Func<T, string> tooltipGenerator) where T : Microsoft.VisualStudio.Language.Intellisense.Completion
+        {
+            foreach (var c in completions)
+            {
+                c.Description = tooltipGenerator(c);
+            }
+            return completions;
         }
     }
 }

--- a/EditorExtensions/WebEssentials2013.csproj
+++ b/EditorExtensions/WebEssentials2013.csproj
@@ -359,6 +359,7 @@
     <Compile Include="Completion\CSS\CustomCompletionListEntry.cs" />
     <Compile Include="Completion\CSS\Filter\GradientCompletionListFilter.cs" />
     <Compile Include="Completion\HTML\AppleLinkCompletion.cs" />
+    <Compile Include="Completion\HTML\StaticListCompletion.cs" />
     <Compile Include="Completion\HTML\MiscMetaCompletion.cs" />
     <Compile Include="Completion\HTML\SimpleHtmlCompletion.cs" />
     <Compile Include="Completion\HTML\TwitterCardCompletion.cs" />


### PR DESCRIPTION
Eliminates 100+ lines of code; should be faster too.

WE won't build due to missing `Microsoft.VisualStudio.Web.BrowserLink`, which I can't find anywhere.
Therefore, I haven't tested this, but unless I made a dumb mistake somewhere, it should work fine.
