### PR TITLE
Run post-build actions in the background

### DIFF
--- a/EditorExtensions/EditorExtensionsPackage.cs
+++ b/EditorExtensions/EditorExtensionsPackage.cs
@@ -115,21 +115,22 @@ namespace MadsKristensen.EditorExtensions
         private void BuildEvents_OnBuildDone(vsBuildScope Scope, vsBuildAction Action)
         {
             if (Action != vsBuildAction.vsBuildActionClean)
-            {
-                if (WESettings.GetBoolean(WESettings.Keys.LessCompileOnBuild))
-                    _dte.Commands.Raise(GuidList.guidBuildCmdSetString, (int)PkgCmdIDList.cmdBuildLess, null, null);
-
-                if (WESettings.GetBoolean(WESettings.Keys.CoffeeScriptCompileOnBuild))
-                    _dte.Commands.Raise(GuidList.guidBuildCmdSetString, (int)PkgCmdIDList.cmdBuildCoffeeScript, null, null);
-
-                _dte.Commands.Raise(GuidList.guidBuildCmdSetString, (int)PkgCmdIDList.cmdBuildBundles, null, null);
-
-                if (WESettings.GetBoolean(WESettings.Keys.RunJsHintOnBuild))
+                System.Threading.Tasks.Task.Run(() =>
                 {
-                    Dispatcher.CurrentDispatcher.BeginInvoke(
-                        new Action(() => JsHintProjectRunner.RunOnAllFilesInProject()), DispatcherPriority.ApplicationIdle, null);
-                }
-            }
+                    if (WESettings.GetBoolean(WESettings.Keys.LessCompileOnBuild))
+                        BuildMenu.BuildLess();
+
+                    if (WESettings.GetBoolean(WESettings.Keys.CoffeeScriptCompileOnBuild))
+                        BuildMenu.BuildCoffeeScript();
+
+                    BuildMenu.UpdateBundleFiles();
+
+                    if (WESettings.GetBoolean(WESettings.Keys.RunJsHintOnBuild))
+                    {
+                        Dispatcher.CurrentDispatcher.BeginInvoke(
+                            new Action(() => JsHintProjectRunner.RunOnAllFilesInProject()), DispatcherPriority.ApplicationIdle, null);
+                    }
+                });
             else if (Action == vsBuildAction.vsBuildActionClean)
             {
                 System.Threading.Tasks.Task.Run(() => JsHintRunner.Reset());

--- a/EditorExtensions/MenuItems/BuildMenu.cs
+++ b/EditorExtensions/MenuItems/BuildMenu.cs
@@ -43,7 +43,7 @@ namespace MadsKristensen.EditorExtensions
             _mcs.AddCommand(menuCoffee);
         }
 
-        private static void BuildCoffeeScript()
+        public static void BuildCoffeeScript()
         {
             foreach (Project project in _dte.Solution.Projects)
             {
@@ -52,14 +52,14 @@ namespace MadsKristensen.EditorExtensions
             }
         }
 
-        private static void UpdateBundleFiles()
+        public static void UpdateBundleFiles()
         {
             //Logger.Log("Updating bundles...");
             BundleFilesMenu.UpdateBundles(null, true);
             //Logger.Log("Bundles updated");
         }
 
-        private static void BuildLess()
+        public static void BuildLess()
         {
             foreach (Project project in _dte.Solution.Projects)
             {


### PR DESCRIPTION
(LESS, & Coffeescript compilation, as well as bundling)

This avoids freezing the UI thread for large solutions.
