### PR TITLE
Refactor ColorConverterSmartTagAction

### DIFF
--- a/EditorExtensions/SmartTags/CSS/Providers/ColorConverterSmartTagProvider.cs
+++ b/EditorExtensions/SmartTags/CSS/Providers/ColorConverterSmartTagProvider.cs
@@ -39,6 +39,7 @@ namespace MadsKristensen.EditorExtensions
 
                 if (model.Format == ColorFormat.RgbHex6)
                 {
+                    model.Format = ColorFormat.RgbHex3;
                     string hex3 = ColorFormatter.FormatColor(model, ColorFormat.RgbHex3);
 
                     if (hex3.Length == 4)


### PR DESCRIPTION
In addition to vastly reducing duplication,
this also fixes a bug.  Converting from rgb
or hsl to hex would show the wrong value in
the title.  (The code forgot to set Format)

This also fixes conversions from RgbHex6 to
RgbHex3, due to a similar issue.

The underlying issue is that ColorFormatter
.FormatColor() takes a fallback format, and
inly uses it if the model's format is Hsb.
