### PR TITLE
Added location info to coffee-script errors

### DIFF
--- a/EditorExtensions/Margin/CoffeeScriptCompiler.cs
+++ b/EditorExtensions/Margin/CoffeeScriptCompiler.cs
@@ -29,10 +29,9 @@ namespace MadsKristensen.EditorExtensions
                     "catch (err){" +
                         "var locationMsg = '';" +
                         "if (err && err.location) {" +
-                            "locationMsg = 'Start Line: ' + err.location.first_line + ', Start Column: ' + err.location.first_column + '\n';" +
-                            "locationMsg += 'Last Line: ' + err.location.last_line + ', Last Column: ' + err.location.last_column + '\n';" +
+                            "locationMsg = err.location.first_line + ':' + err.location.first_column + ':';" +
                         "}" +
-                        "window.external.Execute('ERROR:\n' + locationMsg + err, '" + state.Replace("\\", "\\\\") + "');" +
+                        "window.external.Execute('ERROR:'+locationMsg+err, '" + state.Replace("\\", "\\\\") + "');" +
                     "}";
 
             return "<html><head><meta http-equiv=\"X-UA-Compatible\" content=\"IE=9\" /><script>" + script + "</script></head><html/>";

--- a/EditorExtensions/Margin/CoffeeScriptMargin.cs
+++ b/EditorExtensions/Margin/CoffeeScriptMargin.cs
@@ -2,6 +2,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Windows.Threading;
 
 namespace MadsKristensen.EditorExtensions
@@ -110,18 +111,13 @@ namespace MadsKristensen.EditorExtensions
         private CompilerError ParseError(string error)
         {
             string message = error.Replace("ERROR:", string.Empty).Replace("Error:", string.Empty);
-            int index = message.IndexOf(':');
-            int line = 0;
+            int line = 0, column = 0;
 
-            if (index > -1)
+            Match match = Regex.Match(message, @"^(\d{1,})[:](\d{1,})");
+            if (match.Success)
             {
-                int start = message.LastIndexOf(' ', index);
-                if (start > -1)
-                {
-                    int length = index - start - 1;
-                    string part = message.Substring(start + 1, length);
-                    int.TryParse(part, out line);
-                }
+                int.TryParse(match.Groups[1].Value, out line);
+                int.TryParse(match.Groups[2].Value, out column);
             }
 
             CompilerError result = new CompilerError()
@@ -129,6 +125,7 @@ namespace MadsKristensen.EditorExtensions
                 Message = "CoffeeScript: " + message,
                 FileName = Document.FilePath,
                 Line = line,
+                Column = column
             };
 
             return result;


### PR DESCRIPTION
This change outputs the error location info (if present) when reported by the coffee-script compiler.

I had to test this script change in a html file because I couldn't open the WebEssentials2013.csproj project due to compatibility issues in vs2013 pro v12.0.21005.1

fixes #175
