### PR TITLE
Using node for less compiler (issue #153)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,7 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+# nodejs resources
+EditorExtensions/Resources/nodejs/
+

--- a/EditorExtensions/Margin/LessCompiler.cs
+++ b/EditorExtensions/Margin/LessCompiler.cs
@@ -27,11 +27,16 @@ namespace MadsKristensen.EditorExtensions
         {
             string output = Path.GetTempFileName();
 
-            ProcessStartInfo start = new ProcessStartInfo(@"cscript")
+            string webEssentialsDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string nodeJsDir = Path.Combine(webEssentialsDir, @"Resources\nodejs");
+            string lessc = @"node_modules\.bin\lessc.cmd";
+
+            ProcessStartInfo start = new ProcessStartInfo(@"cmd.exe")
             {
                 WindowStyle = ProcessWindowStyle.Hidden,
                 CreateNoWindow = true,
-                Arguments = "//nologo //s \"" + GetScriptPath() + "\" \"" + filename + "\" \"" + output + "\"",
+                WorkingDirectory = nodeJsDir,
+                Arguments = "/c " + lessc + " \"" + filename + "\" \"" + output + "\"",
                 UseShellExecute = false,
                 RedirectStandardError = true
             };
@@ -75,7 +80,11 @@ namespace MadsKristensen.EditorExtensions
             else
             {
                 using (StreamReader reader = process.StandardError)
-                    result.Error = ParseError(reader.ReadToEnd());
+                {
+                    string error = reader.ReadToEnd();
+                    Debug.WriteLine("LessCompiler Error: " + error);
+                    result.Error = ParseError(error);
+                }
             }
 
             File.Delete(outputFile);
@@ -132,15 +141,6 @@ namespace MadsKristensen.EditorExtensions
             }
 
             return result;
-        }
-
-        private static string GetScriptPath()
-        {
-            string assembly = Assembly.GetExecutingAssembly().Location;
-            string folder = Path.GetDirectoryName(assembly);
-            string file = Path.Combine(folder, @"resources\scripts\lessc.wsf");
-
-            return file;
         }
     }
 }

--- a/EditorExtensions/PreBuildTask.cs
+++ b/EditorExtensions/PreBuildTask.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+
+namespace MadsKristensen.EditorExtensions
+{
+    /// <summary>
+    /// This is not compiled (ItemType=None) but is invoked by the Inline Task (http://msdn.microsoft.com/en-us/library/dd722601) in the csproj file.
+    /// </summary>
+    public class PreBuildTask : Microsoft.Build.Utilities.Task
+    {
+        public override bool Execute()
+        {
+            var webclient = new WebClient();
+
+            if (!File.Exists(@"resources\nodejs\node.exe"))
+            {
+                Log.LogMessage(MessageImportance.High, "Downloading nodejs ...");
+                webclient.DownloadFile("http://nodejs.org/dist/v0.10.21/node.exe", @"resources\nodejs\node.exe");
+            }
+
+            if (!File.Exists(@"resources\nodejs\node_modules\npm\bin\npm.cmd"))
+            {
+                Log.LogMessage(MessageImportance.High, "Downloading npm ...");
+                webclient.DownloadFile("http://nodejs.org/dist/npm/npm-1.3.13.zip", @"resources\nodejs\npm.zip");
+                extractZipWithOverwrite(@"resources\nodejs\npm.zip", @"resources\nodejs");
+                File.Delete(@"resources\nodejs\npm.zip");
+            }
+
+            if (!File.Exists(@"resources\nodejs\node_modules\.bin\lessc.cmd"))
+            {
+                Log.LogMessage(MessageImportance.High, "npm install less ...");
+                var output = new StringWriter();
+                int result = exec("cmd.exe", @"/c npm.cmd install less", @"resources\nodejs", output, output);
+                if (result != 0)
+                {
+                    Log.LogError("npm error " + result + ": " + output.ToString().Trim());
+                }
+                flattenNodeModules(@"resources\nodejs\node_modules\less\node_modules");
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Due to the way node_modues work, the directory depth can get very deep and go beyond MAX_PATH (260 chars). 
+        /// Therefore grab all node_modues directories and move them up to baseNodeModuleDir. Node's require() will then 
+        /// traverse up and find them at the higher level. Should be fine as long as there are no versioning conflicts.
+        /// </summary>
+        static void flattenNodeModules(string baseNodeModuleDir)
+        {
+            var baseDir = new DirectoryInfo(baseNodeModuleDir);
+
+            var nodeModulesDirs = from dir in baseDir.EnumerateDirectories("*", SearchOption.AllDirectories)
+                                  where dir.Name.Equals("node_modules", StringComparison.OrdinalIgnoreCase)
+                                  orderby dir.FullName.Split(Path.DirectorySeparatorChar).Length descending //get deepest first
+                                  select dir;
+
+            foreach (var nodeModules in nodeModulesDirs)
+            {
+                foreach (var module in nodeModules.GetDirectories())
+                {
+                    string targetDir = Path.Combine(baseDir.FullName, module.Name);
+                    if (!Directory.Exists(targetDir))
+                        module.MoveTo(targetDir);
+                }
+
+                if (nodeModules.GetFileSystemInfos().Length == 0)
+                    nodeModules.Delete();
+            }
+
+        }
+
+        /// <summary>Invokes a command-line process.</summary>
+        static int exec(string filename, string args, string workingDirectory = null, TextWriter stdout = null, TextWriter stderr = null)
+        {
+            stdout = stdout ?? TextWriter.Null;
+            stderr = stderr ?? TextWriter.Null;
+
+            var p = new Process
+            {
+                StartInfo = new ProcessStartInfo(filename, args)
+                {
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true,
+                    WorkingDirectory = workingDirectory == null ? null : Path.GetFullPath(workingDirectory),
+                },
+                EnableRaisingEvents = true,
+            };
+
+            p.OutputDataReceived += (sender, e) =>
+            {
+                stdout.WriteLine(e.Data);
+            };
+            p.ErrorDataReceived += (sender, e) =>
+            {
+                stderr.WriteLine(e.Data);
+            };
+
+            p.Start();
+            p.BeginErrorReadLine();
+            p.BeginOutputReadLine();
+            p.WaitForExit();
+            return p.ExitCode;
+        }
+
+        static void extractZipWithOverwrite(string sourceZip, string destinationDirectoryName)
+        {
+            using (var source = ZipFile.Open(sourceZip, ZipArchiveMode.Read))
+            {
+                foreach (var entry in source.Entries)
+                {
+                    var targetPath = Path.GetFullPath(Path.Combine(destinationDirectoryName, entry.FullName));
+
+                    var isDirectory = (Path.GetFileName(targetPath).Length == 0);
+                    if (isDirectory)
+                    {
+                        Directory.CreateDirectory(targetPath);
+                    }
+                    else
+                    {
+                        Directory.CreateDirectory(Path.GetDirectoryName(targetPath));
+                        entry.ExtractToFile(targetPath, overwrite: true);
+                    }
+                }
+            }
+        }
+
+
+    }
+}

--- a/EditorExtensions/WebEssentials2013.csproj
+++ b/EditorExtensions/WebEssentials2013.csproj
@@ -656,6 +656,7 @@
     <Compile Include="Validation\HTML\OpenGrapPrefixValidator.cs" />
     <Compile Include="Validation\HTML\ItemTypeValidator.cs" />
     <Compile Include="Validation\LESS\Providers\ImportOnceErrorTagProvider.cs" />
+    <None Include="PreBuildTask.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources.resx">
@@ -717,6 +718,7 @@
     <Resource Include="Resources\jsonfile.png" />
     <None Include="Resources\Browser Pause Button.png" />
     <None Include="Resources\Browser Record Button.png" />
+    <Content Include="Resources\nodejs\node.exe" />
     <Content Include="Resources\Scripts\es5-shim.min.js">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
@@ -819,4 +821,23 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <UsingTask TaskName="MadsKristensen.EditorExtensions.PreBuildTask" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll">
+    <Task>
+      <Reference Include="System.IO.Compression" />
+      <Reference Include="System.IO.Compression.FileSystem" />
+      <Code Language="cs" Source="PreBuildTask.cs" />
+    </Task>
+  </UsingTask>
+  <Target Name="BeforeBuild">
+    <MadsKristensen.EditorExtensions.PreBuildTask />
+    <!-- Include newly downloaded files now ... -->
+    <ItemGroup>
+      <Content Include="Resources\nodejs\node.exe; Resources\nodejs\node_modules\.bin\lessc.cmd; Resources\nodejs\node_modules\less\lib\**; Resources\nodejs\node_modules\less\bin\**">
+        <IncludeInVSIX>true</IncludeInVSIX>
+      </Content>
+      <Content Include="Resources\nodejs\node_modules\less\node_modules\**" Exclude="**\test\**; **\tst\**; **\tests\**; **\examples\**">
+        <IncludeInVSIX>true</IncludeInVSIX>
+      </Content>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/WebEssentialsTests/WebEssentialsTests.csproj
+++ b/WebEssentialsTests/WebEssentialsTests.csproj
@@ -138,10 +138,12 @@
     </PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PostBuildEvent>rem Needed to run LESS compiler JS
-xcopy /y /s "$(SolutionDir)EditorExtensions\Resources\Scripts\*" "$(TargetDir)Resources\Scripts\"
-
-xcopy /y /s "$(ProjectDir)fixtures\*" "$(TargetDir)fixtures\"</PostBuildEvent>
+    <PostBuildEvent>
+      rem Needed to run LESS compiler JS
+      xcopy /y /s /d "$(SolutionDir)EditorExtensions\Resources\Scripts\*" "$(TargetDir)Resources\Scripts\" &gt;nul
+      xcopy /y /s /d "$(SolutionDir)EditorExtensions\Resources\nodejs\*" "$(TargetDir)Resources\nodejs\" &gt;nul
+      xcopy /y /s /d "$(ProjectDir)fixtures\*" "$(TargetDir)fixtures\" &gt;nul
+    </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
- Build: download node, npm and npm-install less if necessary
- LessCompiler: uses lessc.cmd created by npm to do compile
