### PR TITLE
Invoke LESS compiler in node.exe directory

### DIFF
--- a/EditorExtensions/Margin/LessCompiler.cs
+++ b/EditorExtensions/Margin/LessCompiler.cs
@@ -31,15 +31,16 @@ namespace MadsKristensen.EditorExtensions
             string lessc = Path.Combine(webEssentialsDir, @"Resources\nodejs\node_modules\.bin\lessc.cmd");
             string arguments = String.Format("--relative-urls \"{0}\" \"{1}\"", filename, output);
             if (WESettings.GetBoolean(WESettings.Keys.LessSourceMaps))
-              arguments = String.Format(
-                "--relative-urls --source-map=\"{0}.map\" \"{1}\" \"{2}\"",
-                targetFilename ?? filename,
-                filename,
-                output);
+                arguments = String.Format(
+                  "--relative-urls --source-map=\"{0}.map\" \"{1}\" \"{2}\"",
+                  targetFilename ?? filename,
+                  filename,
+                  output);
 
             ProcessStartInfo start = new ProcessStartInfo(lessc)
             {
                 WindowStyle = ProcessWindowStyle.Hidden,
+                WorkingDirectory = Path.Combine(webEssentialsDir, @"Resources\nodejs"),
                 CreateNoWindow = true,
                 Arguments = arguments,
                 UseShellExecute = false,

--- a/WebEssentialsTests/LessCompilationTests.cs
+++ b/WebEssentialsTests/LessCompilationTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using MadsKristensen.EditorExtensions;
@@ -10,6 +11,19 @@ namespace WebEssentialsTests
     [TestClass]
     public class LessCompilationTests
     {
+        static string originalPath;
+        [ClassInitialize]
+        public static void ObscureNode(TestContext context)
+        {
+            originalPath = Environment.GetEnvironmentVariable("PATH");
+            Environment.SetEnvironmentVariable("PATH", originalPath.Replace(@";C:\Program Files\nodejs\", ""), EnvironmentVariableTarget.Process);
+        }
+        [ClassCleanup]
+        public static void RestoreNode()
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+        }
+
         static readonly string BaseDirectory = Path.GetDirectoryName(typeof(NodeModuleImportedTests).Assembly.Location);
         [TestMethod]
         public async Task PathCompilationTest()


### PR DESCRIPTION
Fixes #196

Includes unit test that removes Node.exe from path.

LESS compilation will now work on systems without Node.js installed.
