### PR TITLE
Allow developer to specify output location for css / coffeescript files.

### DIFF
--- a/EditorExtensions/Margin/CoffeeScriptMargin.cs
+++ b/EditorExtensions/Margin/CoffeeScriptMargin.cs
@@ -148,9 +148,9 @@ namespace MadsKristensen.EditorExtensions
             }
         }
 
-        public override bool UseCompiledFolder
+		public override string UseCompiledFolder
         {
-            get { return WESettings.GetBoolean(WESettings.Keys.CoffeeScriptCompileToFolder); }
+			get { return WESettings.GetString(WESettings.Keys.CoffeeScriptCompileToFolder); }
         }
 
         public override bool IsSaveFileEnabled

--- a/EditorExtensions/Margin/LessMargin.cs
+++ b/EditorExtensions/Margin/LessMargin.cs
@@ -59,9 +59,9 @@ namespace MadsKristensen.EditorExtensions
             }
         }
 
-        public override bool UseCompiledFolder
+        public override string UseCompiledFolder
         {
-            get { return WESettings.GetBoolean(WESettings.Keys.LessCompileToFolder); }
+            get { return WESettings.GetString(WESettings.Keys.LessCompileToFolder); }
         }
 
         public override bool IsSaveFileEnabled

--- a/EditorExtensions/Margin/LessProjectCompiler.cs
+++ b/EditorExtensions/Margin/LessProjectCompiler.cs
@@ -24,7 +24,7 @@ namespace MadsKristensen.EditorExtensions
 
             foreach (string file in files)
             {
-                string cssFileName = MarginBase.GetCompiledFileName(file, ".css", WESettings.GetBoolean(WESettings.Keys.LessCompileToFolder));
+                string cssFileName = MarginBase.GetCompiledFileName(file, ".css", WESettings.GetString(WESettings.Keys.LessCompileToFolder));
                 var result = await LessCompiler.Compile(file, cssFileName);
 
                 if (result.IsSuccess)
@@ -42,11 +42,11 @@ namespace MadsKristensen.EditorExtensions
             if (Path.GetFileName(fileName).StartsWith("_"))
                 return false;
 
-            string minFile = MarginBase.GetCompiledFileName(fileName, ".min.css", WESettings.GetBoolean(WESettings.Keys.LessCompileToFolder));
+			string minFile = MarginBase.GetCompiledFileName(fileName, ".min.css", WESettings.GetString(WESettings.Keys.LessCompileToFolder));
             if (File.Exists(minFile) && WESettings.GetBoolean(WESettings.Keys.LessMinify))
                 return true;
 
-            string cssFile = MarginBase.GetCompiledFileName(fileName, ".css", WESettings.GetBoolean(WESettings.Keys.LessCompileToFolder));
+			string cssFile = MarginBase.GetCompiledFileName(fileName, ".css", WESettings.GetString(WESettings.Keys.LessCompileToFolder));
             if (!File.Exists(cssFile))
                 return false;
 
@@ -82,7 +82,7 @@ namespace MadsKristensen.EditorExtensions
             if (WESettings.GetBoolean(WESettings.Keys.LessMinify))
             {
                 string content = MinifyFileMenu.MinifyString(".css", source);
-                string minFile = MarginBase.GetCompiledFileName(lessFileName, ".min.css", WESettings.GetBoolean(WESettings.Keys.LessCompileToFolder)); //lessFileName.Replace(".less", ".min.css");
+				string minFile = MarginBase.GetCompiledFileName(lessFileName, ".min.css", WESettings.GetString(WESettings.Keys.LessCompileToFolder)); //lessFileName.Replace(".less", ".min.css");
                 bool fileExist = File.Exists(minFile);
                 string old = fileExist ? File.ReadAllText(minFile) : string.Empty;
 

--- a/EditorExtensions/Margin/MarkdownMargin.cs
+++ b/EditorExtensions/Margin/MarkdownMargin.cs
@@ -132,9 +132,9 @@ namespace MadsKristensen.EditorExtensions
             // Nothing to minify
         }
 
-        public override bool UseCompiledFolder
+		public override string UseCompiledFolder
         {
-            get { return false; }
+            get { return null; }
         }
 
         public override bool IsSaveFileEnabled

--- a/EditorExtensions/Options/Less.cs
+++ b/EditorExtensions/Options/Less.cs
@@ -28,7 +28,7 @@ namespace MadsKristensen.EditorExtensions
             ShowLessPreviewWindow = WESettings.GetBoolean(WESettings.Keys.ShowLessPreviewWindow);
             LessMinify = WESettings.GetBoolean(WESettings.Keys.LessMinify);
             LessCompileOnBuild = WESettings.GetBoolean(WESettings.Keys.LessCompileOnBuild);
-            LessCompileToFolder = WESettings.GetBoolean(WESettings.Keys.LessCompileToFolder);
+            LessCompileToFolder = WESettings.GetString(WESettings.Keys.LessCompileToFolder);
             LessSourceMaps = WESettings.GetBoolean(WESettings.Keys.LessSourceMaps);
         }
 
@@ -57,9 +57,9 @@ namespace MadsKristensen.EditorExtensions
         [Category("LESS")]
         public bool LessCompileOnBuild { get; set; }
 
-        [LocDisplayName("Compile to 'css' folder")]
-        [Description("Compiles each LESS file into a folder called 'css' in the same directory as the .less file.")]
+        [LocDisplayName("Compile to a custom folder")]
+        [Description("Compiles each LESS file into a custom folder. Prefix your output directory with a `/` to indicate that it starts at the project's root directory. Otherwise a relative path is assumed. Leave empty to effectively disable this option.")]
         [Category("LESS")]
-        public bool LessCompileToFolder { get; set; }
+        public string LessCompileToFolder { get; set; }
     }
 }

--- a/EditorExtensions/Source.extension.vsixmanifest
+++ b/EditorExtensions/Source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="5fb7364d-2e8c-44a4-95eb-2a382e30fec8" Version="1.3.1" Language="en-US" Publisher="Mads Kristensen" />
+    <Identity Id="5fb7364d-2e8c-44a4-95eb-2a382e30fec8" Version="1.3.2" Language="en-US" Publisher="Mads Kristensen" />
     <DisplayName>Web Essentials 2013</DisplayName>
     <Description xml:space="preserve">Adds many useful features to Visual Studio for web developers.</Description>
     <MoreInfo>http://vswebessentials.com/</MoreInfo>


### PR DESCRIPTION
I changed the `UseCompiledFolder` property of MarginBase, LessMargin, and CoffeeScriptMargin to be a string so that the developer can specify where to output compiled css (and coffeescript files).

I also added one to the version number to get the vsix to overwrite existing install.. I don't know if that matters (you would have seen it anyway, I'm sure)..

It works great on my machine! :-P

Thanks for a great extension! 
