### PR TITLE
More updates.. Yeah, maybe went a little crazy with this one.. What do you think about setting the defaults? Where would you like those set?

### DIFF
--- a/EditorExtensions/EditorExtensionsPackage.cs
+++ b/EditorExtensions/EditorExtensionsPackage.cs
@@ -26,6 +26,7 @@ namespace MadsKristensen.EditorExtensions
     [ProvideOptionPage(typeof(CoffeeScriptOptions), "Web Essentials", "CoffeeScript", 101, 106, true, new[] { "Iced", "JavaScript", "JS", "JScript" })]
     [ProvideOptionPage(typeof(JavaScriptOptions), "Web Essentials", "JavaScript", 101, 107, true, new[] { "JScript", "JS", "Minify", "Minification", "EcmaScript" })]
     [ProvideOptionPage(typeof(UnusedCssOptions), "Web Essentials", "Unused CSS", 101, 108, true, new[] { "Ignore", "Filter" })]
+    [ProvideOptionPage(typeof(MarkdownOptions), "Web Essentials", "Markdown", 101, 109, true, new[] { "markdown", "Markdown", "md" })]
     public sealed class EditorExtensionsPackage : Package
     {
         private static DTE2 _dte;

--- a/EditorExtensions/Margin/EditorMarginFactory.cs
+++ b/EditorExtensions/Margin/EditorMarginFactory.cs
@@ -23,18 +23,19 @@ namespace MadsKristensen.EditorExtensions
 
             if (textViewHost.TextView.TextDataModel.DocumentBuffer.Properties.TryGetProperty(typeof(ITextDocument), out document))
             {
-                switch (textViewHost.TextView.TextBuffer.ContentType.DisplayName)
+                switch (textViewHost.TextView.TextBuffer.ContentType.DisplayName.ToLowerInvariant())
                 {
-                    case "LESS":
+                    case "less":
                         bool showLess = WESettings.GetBoolean(WESettings.Keys.ShowLessPreviewWindow);
                         return new LessMargin("CSS", source, showLess, document);
 
-                    case "CoffeeScript":
+                    case "coffeescript":
                         bool showCoffee = WESettings.GetBoolean(WESettings.Keys.ShowCoffeeScriptPreviewWindow);
                         return new CoffeeScriptMargin("JavaScript", source, showCoffee, document);
 
                     case "markdown":
-                        return new MarkdownMargin("text", source, true, document);
+                        bool showMarkdown = WESettings.GetBoolean(WESettings.Keys.MarkdownShowPreviewWindow);
+                        return new MarkdownMargin("text", source, showMarkdown, document);
                 }
             }
 

--- a/EditorExtensions/Margin/LessMargin.cs
+++ b/EditorExtensions/Margin/LessMargin.cs
@@ -15,7 +15,10 @@ namespace MadsKristensen.EditorExtensions
 
         protected override async void StartCompiler(string source)
         {
-            string cssFilename = GetCompiledFileName(Document.FilePath, ".css", UseCompiledFolder);// Document.FilePath.Replace(".less", ".css");
+            if (!CompileEnabled)
+                return;
+
+            string cssFilename = GetCompiledFileName(Document.FilePath, ".css", CompileEnabled ? CompileToLocation : null);// Document.FilePath.Replace(".less", ".css");
 
             if (IsFirstRun && File.Exists(cssFilename))
             {
@@ -42,10 +45,13 @@ namespace MadsKristensen.EditorExtensions
 
         public override void MinifyFile(string fileName, string source)
         {
+            if (!CompileEnabled)
+                return;
+
             if (WESettings.GetBoolean(WESettings.Keys.LessMinify) && !Path.GetFileName(fileName).StartsWith("_"))
             {
                 string content = MinifyFileMenu.MinifyString(".css", source);
-                string minFile = GetCompiledFileName(fileName, ".min.css", UseCompiledFolder);// fileName.Replace(".less", ".min.css");
+                string minFile = GetCompiledFileName(fileName, ".min.css", CompileToLocation);// fileName.Replace(".less", ".min.css");
                 bool fileExist = File.Exists(minFile);
 
                 ProjectHelpers.CheckOutFileFromSourceControl(minFile);
@@ -59,9 +65,14 @@ namespace MadsKristensen.EditorExtensions
             }
         }
 
-        public override string UseCompiledFolder
+        public override bool CompileEnabled
         {
-            get { return WESettings.GetString(WESettings.Keys.LessCompileToFolder); }
+            get { return WESettings.GetBoolean(WESettings.Keys.LessEnableCompiler); }
+        }
+
+        public override string CompileToLocation
+        {
+            get { return WESettings.GetString(WESettings.Keys.LessCompileToLocation); }
         }
 
         public override bool IsSaveFileEnabled

--- a/EditorExtensions/Margin/LessProjectCompiler.cs
+++ b/EditorExtensions/Margin/LessProjectCompiler.cs
@@ -24,7 +24,7 @@ namespace MadsKristensen.EditorExtensions
 
             foreach (string file in files)
             {
-                string cssFileName = MarginBase.GetCompiledFileName(file, ".css", WESettings.GetString(WESettings.Keys.LessCompileToFolder));
+                string cssFileName = MarginBase.GetCompiledFileName(file, ".css", WESettings.GetString(WESettings.Keys.LessCompileToLocation));
                 var result = await LessCompiler.Compile(file, cssFileName);
 
                 if (result.IsSuccess)
@@ -42,11 +42,11 @@ namespace MadsKristensen.EditorExtensions
             if (Path.GetFileName(fileName).StartsWith("_"))
                 return false;
 
-			string minFile = MarginBase.GetCompiledFileName(fileName, ".min.css", WESettings.GetString(WESettings.Keys.LessCompileToFolder));
+            string minFile = MarginBase.GetCompiledFileName(fileName, ".min.css", WESettings.GetString(WESettings.Keys.LessCompileToLocation));
             if (File.Exists(minFile) && WESettings.GetBoolean(WESettings.Keys.LessMinify))
                 return true;
 
-			string cssFile = MarginBase.GetCompiledFileName(fileName, ".css", WESettings.GetString(WESettings.Keys.LessCompileToFolder));
+            string cssFile = MarginBase.GetCompiledFileName(fileName, ".css", WESettings.GetString(WESettings.Keys.LessCompileToLocation));
             if (!File.Exists(cssFile))
                 return false;
 
@@ -82,7 +82,7 @@ namespace MadsKristensen.EditorExtensions
             if (WESettings.GetBoolean(WESettings.Keys.LessMinify))
             {
                 string content = MinifyFileMenu.MinifyString(".css", source);
-				string minFile = MarginBase.GetCompiledFileName(lessFileName, ".min.css", WESettings.GetString(WESettings.Keys.LessCompileToFolder)); //lessFileName.Replace(".less", ".min.css");
+                string minFile = MarginBase.GetCompiledFileName(lessFileName, ".min.css", WESettings.GetString(WESettings.Keys.LessCompileToLocation)); //lessFileName.Replace(".less", ".min.css");
                 bool fileExist = File.Exists(minFile);
                 string old = fileExist ? File.ReadAllText(minFile) : string.Empty;
 

--- a/EditorExtensions/Margin/MarkdownMargin.cs
+++ b/EditorExtensions/Margin/MarkdownMargin.cs
@@ -28,8 +28,13 @@ namespace MadsKristensen.EditorExtensions
         {
             if (_compiler == null)
             {
-                MarkdownOptions options = new MarkdownOptions();
-                options.AutoHyperlink = true;
+                MarkdownSharp.MarkdownOptions options = new MarkdownSharp.MarkdownOptions();
+                options.AutoHyperlink = AutoHyperlinks;
+                options.LinkEmails = LinkEmails;
+                options.AutoNewLines = AutoNewLines;
+                options.EmptyElementSuffix = GenerateXHTML ? "/>" : ">";
+                options.EncodeProblemUrlCharacters = EncodeProblemUrlCharacters;
+                options.StrictBoldItalic = StrictBoldItalic;
 
                 _compiler = new Markdown(options);
             }
@@ -47,6 +52,27 @@ namespace MadsKristensen.EditorExtensions
                           "<body>" + result + "</body></html>";
 
             _browser.NavigateToString(html);
+
+            // NOTE: Markdown files are always compiled for the Preview window.
+            //       But, only saved to disk when the CompileEnabled flag is true.
+            //       That is why the following if statement is not wrapping this whole method.
+            if (CompileEnabled)
+            {
+                string htmlFilename = GetCompiledFileName(Document.FilePath, ".html", CompileToLocation);
+                try
+                {
+                    if (File.Exists(htmlFilename))
+                    {
+                        File.SetAttributes(htmlFilename, FileAttributes.Normal);
+                        File.Delete(htmlFilename);
+                    }
+                    File.WriteAllText(htmlFilename, html);
+                }
+                catch (Exception ex)
+                {
+                    // TODO not sure what to do here..
+                }
+            }
         }
 
         public static string GetStylesheet()
@@ -132,11 +158,6 @@ namespace MadsKristensen.EditorExtensions
             // Nothing to minify
         }
 
-		public override string UseCompiledFolder
-        {
-            get { return null; }
-        }
-
         public override bool IsSaveFileEnabled
         {
             get { return false; }
@@ -145,6 +166,46 @@ namespace MadsKristensen.EditorExtensions
         protected override bool CanWriteToDisk(string source)
         {
             return false;
+        }
+
+        public override bool CompileEnabled
+        {
+            get { return WESettings.GetBoolean(WESettings.Keys.MarkdownEnableCompiler); }
+        }
+
+        public override string CompileToLocation
+        {
+            get { return WESettings.GetString(WESettings.Keys.MarkdownCompileToLocation); }
+        }
+
+        public bool AutoHyperlinks
+        {
+            get { return WESettings.GetBoolean(WESettings.Keys.MarkdownAutoHyperlinks); }
+        }
+
+        public bool LinkEmails
+        {
+            get { return WESettings.GetBoolean(WESettings.Keys.MarkdownLinkEmails); }
+        }
+
+        public bool AutoNewLines
+        {
+            get { return WESettings.GetBoolean(WESettings.Keys.MarkdownAutoNewLine); }
+        }
+
+        public bool GenerateXHTML
+        {
+            get { return WESettings.GetBoolean(WESettings.Keys.MarkdownGenerateXHTML); }
+        }
+
+        public bool EncodeProblemUrlCharacters
+        {
+            get { return WESettings.GetBoolean(WESettings.Keys.MarkdownEncodeProblemUrlCharacters); }
+        }
+
+        public bool StrictBoldItalic
+        {
+            get { return WESettings.GetBoolean(WESettings.Keys.MarkdownStrictBoldItalic); }
         }
     }
 }

--- a/EditorExtensions/Options/CoffeeScript.cs
+++ b/EditorExtensions/Options/CoffeeScript.cs
@@ -16,8 +16,9 @@ namespace MadsKristensen.EditorExtensions
             Settings.SetValue(WESettings.Keys.ShowCoffeeScriptPreviewWindow, ShowCoffeeScriptPreviewWindow);
             Settings.SetValue(WESettings.Keys.WrapCoffeeScriptClosure, WrapCoffeeScriptClosure);
             Settings.SetValue(WESettings.Keys.CoffeeScriptMinify, CoffeeScriptMinify);
-            Settings.SetValue(WESettings.Keys.CoffeeScriptCompileToFolder, CoffeeScriptCompileToFolder);
             Settings.SetValue(WESettings.Keys.CoffeeScriptCompileOnBuild, CoffeeScriptCompileOnBuild);
+            Settings.SetValue(WESettings.Keys.CoffeeScriptEnableCompiler, CoffeeScriptEnableCompiler);
+            Settings.SetValue(WESettings.Keys.CoffeeScriptCompileToLocation, CoffeeScriptCompileToLocation);
 
             Settings.Save();
         }
@@ -28,38 +29,51 @@ namespace MadsKristensen.EditorExtensions
             ShowCoffeeScriptPreviewWindow = WESettings.GetBoolean(WESettings.Keys.ShowCoffeeScriptPreviewWindow);
             WrapCoffeeScriptClosure = WESettings.GetBoolean(WESettings.Keys.WrapCoffeeScriptClosure);
             CoffeeScriptMinify = WESettings.GetBoolean(WESettings.Keys.CoffeeScriptMinify);
-            CoffeeScriptCompileToFolder = WESettings.GetBoolean(WESettings.Keys.CoffeeScriptCompileToFolder);
             CoffeeScriptCompileOnBuild = WESettings.GetBoolean(WESettings.Keys.CoffeeScriptCompileOnBuild);
+            CoffeeScriptEnableCompiler = WESettings.GetBoolean(WESettings.Keys.CoffeeScriptEnableCompiler);
+            CoffeeScriptCompileToLocation = WESettings.GetString(WESettings.Keys.CoffeeScriptCompileToLocation);
         }
 
         [LocDisplayName("Generate JavaScript file on save")]
         [Description("Generates JavaScript file when CoffeeScript file is saved.")]
         [Category("CoffeeScript")]
+        [DefaultValue(true)]
         public bool GenerateJsFileFromCoffeeScript { get; set; }
 
         [LocDisplayName("Show preview pane")]
         [Description("Shows the preview pane when editing a CoffeeScript file.")]
         [Category("CoffeeScript")]
+        [DefaultValue(true)]
         public bool ShowCoffeeScriptPreviewWindow { get; set; }
 
         [LocDisplayName("Wrap generated JavaScript files on save")]
         [Description("Wraps the generated JavaScript in an anonymous function.")]
         [Category("CoffeeScript")]
+        [DefaultValue(false)]
         public bool WrapCoffeeScriptClosure { get; set; }
-        
+
         [LocDisplayName("Minify generated JavaScript")]
         [Description("Creates a minified version of the compiled JavaScript file (file.min.js).")]
         [Category("CoffeeScript")]
+        [DefaultValue(true)]
         public bool CoffeeScriptMinify { get; set; }
-
-        [LocDisplayName("Compile to 'js' folder")]
-        [Description("Compiles all CoffeeScript files into a folder called 'js' in the same directory as the .coffee file.")]
-        [Category("CoffeeScript")]
-        public bool CoffeeScriptCompileToFolder { get; set; }
 
         [LocDisplayName("Compile on build")]
         [Description("Compiles all CoffeeScript files in the project that has a corresponding .js file.")]
         [Category("CoffeeScript")]
+        [DefaultValue(false)]
         public bool CoffeeScriptCompileOnBuild { get; set; }
+
+        [LocDisplayName("Enable CoffeeScript compiler")]
+        [Description("Enables compiling CoffeeScript files. When false, no CoffeeScript files will be compiled to JavaScript, including during a build.")]
+        [Category("CoffeeScript")]
+        [DefaultValue(true)]
+        public bool CoffeeScriptEnableCompiler { get; set; }
+
+        [LocDisplayName("Compile to a custom folder")]
+        [Description("Compiles each CoffeeScript file into a custom folder. Leave empty or `.` to save the compiled .js file to the same directory as the .coffee file. Or, prefix your output directory with a `/` to indicate that it starts at the project's root directory (for example '/js' or '/scripts') - this will apply to ALL .coffee files! Otherwise, a relative path is assumed (starting from the file being compiled) - this may cause the output path to be different for each .coffee file.")]
+        [Category("CoffeeScript")]
+        [DefaultValue("")]
+        public string CoffeeScriptCompileToLocation { get; set; }
     }
 }

--- a/EditorExtensions/Options/Less.cs
+++ b/EditorExtensions/Options/Less.cs
@@ -16,8 +16,9 @@ namespace MadsKristensen.EditorExtensions
             Settings.SetValue(WESettings.Keys.ShowLessPreviewWindow, ShowLessPreviewWindow);
             Settings.SetValue(WESettings.Keys.LessMinify, LessMinify);
             Settings.SetValue(WESettings.Keys.LessCompileOnBuild, LessCompileOnBuild);
-            Settings.SetValue(WESettings.Keys.LessCompileToFolder, LessCompileToFolder);
             Settings.SetValue(WESettings.Keys.LessSourceMaps, LessSourceMaps);
+            Settings.SetValue(WESettings.Keys.LessEnableCompiler, LessEnableCompiler);
+            Settings.SetValue(WESettings.Keys.LessCompileToLocation, LessCompileToLocation);
 
             Settings.Save();
         }
@@ -28,8 +29,9 @@ namespace MadsKristensen.EditorExtensions
             ShowLessPreviewWindow = WESettings.GetBoolean(WESettings.Keys.ShowLessPreviewWindow);
             LessMinify = WESettings.GetBoolean(WESettings.Keys.LessMinify);
             LessCompileOnBuild = WESettings.GetBoolean(WESettings.Keys.LessCompileOnBuild);
-            LessCompileToFolder = WESettings.GetString(WESettings.Keys.LessCompileToFolder);
             LessSourceMaps = WESettings.GetBoolean(WESettings.Keys.LessSourceMaps);
+            LessEnableCompiler = WESettings.GetBoolean(WESettings.Keys.LessEnableCompiler);
+            LessCompileToLocation = WESettings.GetString(WESettings.Keys.LessCompileToLocation);
         }
 
         [LocDisplayName("Generate CSS file on save")]
@@ -57,9 +59,14 @@ namespace MadsKristensen.EditorExtensions
         [Category("LESS")]
         public bool LessCompileOnBuild { get; set; }
 
-        [LocDisplayName("Compile to a custom folder")]
-        [Description("Compiles each LESS file into a custom folder. Prefix your output directory with a `/` to indicate that it starts at the project's root directory. Otherwise a relative path is assumed. Leave empty to effectively disable this option.")]
+        [LocDisplayName("Enable LESS compiler")]
+        [Description("Enables compiling LESS files. When false, no LESS files will be compiled to CSS, including during a build.")]
         [Category("LESS")]
-        public string LessCompileToFolder { get; set; }
+        public bool LessEnableCompiler { get; set; }
+
+        [LocDisplayName("Compile to a custom folder")]
+        [Description("Compiles each LESS file into a custom folder. Leave empty to save the compiled .css file to the same directory as the .less file. Or, prefix your output directory with a `/` to indicate that it starts at the project's root directory (for example '/css' or '/styles') - this will apply to ALL .less files! Otherwise, a relative path is assumed (starting from the file being compiled) - this may cause the output path to be different for each .less file.")]
+        [Category("LESS")]
+        public string LessCompileToLocation { get; set; }
     }
 }

--- a/EditorExtensions/Options/Markdown.cs
+++ b/EditorExtensions/Options/Markdown.cs
@@ -1,0 +1,97 @@
+﻿using System.ComponentModel;
+using Microsoft.VisualStudio.Shell;
+
+namespace MadsKristensen.EditorExtensions
+{
+    class MarkdownOptions : DialogPage // MarkdownSharp.MarkdownOptions
+    {
+        public MarkdownOptions()
+        {
+            Settings.Updated += delegate { LoadSettingsFromStorage(); };
+        }
+
+        public override void SaveSettingsToStorage()
+        {
+            Settings.SetValue(WESettings.Keys.MarkdownShowPreviewWindow, ShowPreviewWindow);
+            Settings.SetValue(WESettings.Keys.MarkdownEnableCompiler, MarkdownEnableCompiler);
+            Settings.SetValue(WESettings.Keys.MarkdownCompileToLocation, MarkdownCompileToLocation ?? "");
+
+            Settings.SetValue(WESettings.Keys.MarkdownAutoHyperlinks, MarkdownAutoHyperlinks);
+            Settings.SetValue(WESettings.Keys.MarkdownLinkEmails, MarkdownLinkEmails);
+            Settings.SetValue(WESettings.Keys.MarkdownAutoNewLine, MarkdownAutoNewLines);
+            Settings.SetValue(WESettings.Keys.MarkdownGenerateXHTML, MarkdownGenerateXHTML);
+            Settings.SetValue(WESettings.Keys.MarkdownEncodeProblemUrlCharacters, MarkdownEncodeProblemUrlCharacters);
+            Settings.SetValue(WESettings.Keys.MarkdownStrictBoldItalic, MarkdownStrictBoldItalic);
+
+            Settings.Save();
+        }
+
+        public override void LoadSettingsFromStorage()
+        {
+            ShowPreviewWindow = WESettings.GetBoolean(WESettings.Keys.MarkdownShowPreviewWindow);
+            MarkdownEnableCompiler = WESettings.GetBoolean(WESettings.Keys.MarkdownEnableCompiler);
+            MarkdownCompileToLocation = WESettings.GetString(WESettings.Keys.MarkdownCompileToLocation);
+
+            MarkdownAutoHyperlinks = WESettings.GetBoolean(WESettings.Keys.MarkdownAutoHyperlinks);
+            MarkdownLinkEmails = WESettings.GetBoolean(WESettings.Keys.MarkdownLinkEmails);
+            MarkdownAutoNewLines = WESettings.GetBoolean(WESettings.Keys.MarkdownAutoNewLine);
+            MarkdownGenerateXHTML = WESettings.GetBoolean(WESettings.Keys.MarkdownGenerateXHTML);
+            MarkdownEncodeProblemUrlCharacters = WESettings.GetBoolean(WESettings.Keys.MarkdownEncodeProblemUrlCharacters);
+            MarkdownStrictBoldItalic = WESettings.GetBoolean(WESettings.Keys.MarkdownStrictBoldItalic);
+        }
+
+        [LocDisplayName("Show preview window")]
+        [Description("Shows the preview window when editing a Markdown file.")]
+        [Category("Preview")]
+        [DefaultValue(true)]
+        public bool ShowPreviewWindow { get; set; }
+
+        [LocDisplayName("Save compiled Markdown files to disk")]
+        [Description("Enables saving Markdown files to disk. When false, no generated HTML files will be saved to disk, including during a build.")]
+        [Category("Compile")]
+        [DefaultValue(false)]
+        public bool MarkdownEnableCompiler { get; set; }
+
+        [LocDisplayName("Save output to a custom folder")]
+        [Description("Saves each Markdown file into a custom folder. Compiled Markdown files (.html) are not saved by default. Leave empty to save the compiled .html file to the same directory as the .md file. Or, prefix your output directory with a `/` to indicate that it starts at the project's root directory (for example '/html') - this will apply to ALL .md files! Otherwise, a relative path is assumed (starting from the file being compiled) - this may cause the output path to be different for each .html file compiled. Leave empty to effectively disable this option, nothing is saved to disk.")]
+        [Category("Compile")]
+        [DefaultValue("")]
+        public string MarkdownCompileToLocation { get; set; }
+
+        [LocDisplayName("Make bare Urls into hyperlinks")]
+        [Description("When true, (most) bare plain Urls are auto-hyperlinked. WARNING: this is a significant deviation from the markdown spec.")]
+        [Category("Compile Options")]
+        [DefaultValue(false)]
+        public bool MarkdownAutoHyperlinks { get; set; }
+
+        [LocDisplayName("Make bare emails into links")]
+        [Description("When false, email addresses will never be auto-linked. WARNING: this is a significant deviation from the markdown spec.")]
+        [Category("Compile Options")]
+        [DefaultValue(false)]
+        public bool MarkdownLinkEmails { get; set; }
+
+        [LocDisplayName("Make return into a newline")]
+        [Description("When true, RETURN becomes a literal newline. WARNING: this is a significant deviation from the markdown spec.")]
+        [Category("Compile Options")]
+        [DefaultValue(false)]
+        public bool MarkdownAutoNewLines { get; set; }
+
+        [LocDisplayName("Generate XHTML output")]
+        [Description("When true, the output is valid XHTML. Otherwise regular HTML it output. In this case, when true (mostly) means that single tags are closed with `/>` instead of `>`.")]
+        [Category("Compile Options")]
+        [DefaultValue(true)]
+        public bool MarkdownGenerateXHTML { get; set; }
+
+        [LocDisplayName("Encode problem Url characters")]
+        [Description("When true, problematic Url characters like [, ], (, and so forth will be encoded. WARNING: this is a significant deviation from the markdown spec.")]
+        [Category("Compile Options")]
+        [DefaultValue(false)]
+        public bool MarkdownEncodeProblemUrlCharacters { get; set; }
+
+        [LocDisplayName("Require non-word characters for bold/italic")]
+        [Description("When true, bold and italic require non-word characters on both sides. WARNING: this is a significant deviation from the markdown spec.")]
+        [Category("Compile Options")]
+        [DefaultValue(false)]
+        public bool MarkdownStrictBoldItalic { get; set; }
+    }
+}

--- a/EditorExtensions/Options/ProjectSettingsStore.cs
+++ b/EditorExtensions/Options/ProjectSettingsStore.cs
@@ -249,23 +249,37 @@ namespace MadsKristensen.EditorExtensions
             dic.Add(Keys.EnableBrowserLinkMenu, true);
             dic.Add(Keys.BrowserLink_ShowMenu, true);
 
-            
             // LESS
             dic.Add(Keys.GenerateCssFileFromLess, true);
             dic.Add(Keys.ShowLessPreviewWindow, true);
             dic.Add(Keys.LessMinify, true);
-
+            dic.Add(Keys.LessEnableCompiler, true);
+            dic.Add(Keys.LessCompileToLocation, true);
 
             // CoffeeScript
             dic.Add(Keys.GenerateJsFileFromCoffeeScript, true);
             dic.Add(Keys.ShowCoffeeScriptPreviewWindow, true);
+            dic.Add(Keys.CoffeeScriptEnableCompiler, true);
+            dic.Add(Keys.CoffeeScriptCompileToLocation, true);
+
+            // Markdown
+            dic.Add(Keys.MarkdownShowPreviewWindow, true);
+            dic.Add(Keys.MarkdownEnableCompiler, true);
+            dic.Add(Keys.MarkdownCompileToLocation, true);
+
+            dic.Add(Keys.MarkdownAutoHyperlinks, true);
+            dic.Add(Keys.MarkdownLinkEmails, true);
+            dic.Add(Keys.MarkdownAutoNewLine, true);
+            dic.Add(Keys.MarkdownGenerateXHTML, true);
+            dic.Add(Keys.MarkdownEncodeProblemUrlCharacters, true);
+            dic.Add(Keys.MarkdownStrictBoldItalic, true);
 
             // CSS
             dic.Add(Keys.CssErrorLocation, (int)Keys.ErrorLocation.Messages);
             dic.Add(Keys.SyncVendorValues, true);
             dic.Add(Keys.ShowUnsupported, true);
 
-            //JSHint
+            // JSHint
             dic.Add(Keys.EnableJsHint, true);
             dic.Add(Keys.JsHintErrorLocation, (int)Keys.FullErrorLocation.Messages);
             dic.Add(Keys.JsHint_bitwise, true);
@@ -284,19 +298,18 @@ namespace MadsKristensen.EditorExtensions
             dic.Add(Keys.JsHint_unused, true);
             dic.Add(Keys.JsHint_ignoreFiles, "kendo.*; globalize.*");
 
-            // MISC
+            // Misc
             dic.Add(Keys.ShowBrowserTooltip, true);
             dic.Add(Keys.WrapCoffeeScriptClosure, true);
 
             // Minification
             dic.Add(Keys.EnableCssMinification, true);
             dic.Add(Keys.EnableJsMinification, true);
-
-            // Minification
             dic.Add(Keys.CoffeeScriptMinify, true);
-           
 
+            // Source Maps
             dic.Add(Keys.GenerateJavaScriptSourceMaps, true);
+            dic.Add(Keys.LessSourceMaps, true);
 
             // Unused CSS
             //Bootstrap, Reset, Normalize, JQuery (UI), Toastr, Foundation, Animate, Inuit, LESS Elements, Ratchet, Hint.css, Flat UI, 960.gs, Skeleton

--- a/EditorExtensions/Options/WebEssentialsSettings.cs
+++ b/EditorExtensions/Options/WebEssentialsSettings.cs
@@ -15,16 +15,30 @@ namespace MadsKristensen.EditorExtensions
             public const string ShowLessPreviewWindow = "LessShowPreviewWindow";
             public const string LessMinify = "LessMinify";
             public const string LessCompileOnBuild = "LessCompileOnBuild";
-            public const string LessCompileToFolder = "LessCompileToFolder";
             public const string LessSourceMaps = "LessSourceMaps";
+            public const string LessEnableCompiler = "LessEnableCompiler";
+            public const string LessCompileToLocation = "LessCompileToLocation";
 
             // CoffeeScript
             public const string GenerateJsFileFromCoffeeScript = "CoffeeScriptGenerateJsFile";
             public const string ShowCoffeeScriptPreviewWindow = "CoffeeScriptShowPreviewWindow";
             public const string CoffeeScriptMinify = "CoffeeScriptMinify";
             public const string WrapCoffeeScriptClosure = "CoffeeScriptWrapClosure";
-            public const string CoffeeScriptCompileToFolder = "CoffeeScriptCompileToFolder";
             public const string CoffeeScriptCompileOnBuild = "CoffeeScriptCompileOnBuild";
+            public const string CoffeeScriptEnableCompiler = "CoffeeScriptEnableCompiler";
+            public const string CoffeeScriptCompileToLocation = "CoffeeScriptCompileToLocation";
+
+            // Markdown
+            public const string MarkdownShowPreviewWindow = "MarkdownShowPreviewWindow";
+            public const string MarkdownEnableCompiler = "MarkdownEnableCompiler";
+            public const string MarkdownCompileToLocation = "MarkdownCompileToLocation";
+
+            public const string MarkdownAutoHyperlinks = "MarkdownAutoHyperlinks";
+            public const string MarkdownLinkEmails = "MarkdownLinkEmails";
+            public const string MarkdownAutoNewLine = "MarkdownAutoNewLine";
+            public const string MarkdownGenerateXHTML = "MarkdownGenerateXHTML";
+            public const string MarkdownEncodeProblemUrlCharacters = "MarkdownEncodeProblemUrlCharacters";
+            public const string MarkdownStrictBoldItalic = "MarkdownStrictBoldItalic";
 
             // CSS
             public const string ValidateStarSelector = "CssValidateStarSelector";
@@ -44,7 +58,7 @@ namespace MadsKristensen.EditorExtensions
             public const string EnableJsMinification = "JavaScriptEnableMinification";
             public const string GenerateJavaScriptSourceMaps = "JavaScriptGenerateSourceMaps";
             public const string JavaScriptEnableGzipping = "JavaScriptEnableGzipping";
-            
+
             // JSHint
             public const string EnableJsHint = "JsHintEnable";
             public const string JsHint_ignoreFiles = "JsHint_ignoreFiles";

--- a/EditorExtensions/Source.extension.vsixmanifest
+++ b/EditorExtensions/Source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="5fb7364d-2e8c-44a4-95eb-2a382e30fec8" Version="1.3.2" Language="en-US" Publisher="Mads Kristensen" />
+    <Identity Id="5fb7364d-2e8c-44a4-95eb-2a382e30fec8" Version="1.3.13" Language="en-US" Publisher="Mads Kristensen" />
     <DisplayName>Web Essentials 2013</DisplayName>
     <Description xml:space="preserve">Adds many useful features to Visual Studio for web developers.</Description>
     <MoreInfo>http://vswebessentials.com/</MoreInfo>

--- a/EditorExtensions/WebEssentials2013.csproj
+++ b/EditorExtensions/WebEssentials2013.csproj
@@ -447,6 +447,9 @@
     <Compile Include="MenuItems\ReferenceJs.cs" />
     <Compile Include="NavigateTo\CSS\CssGoToLineTag.cs" />
     <Compile Include="NavigateTo\CSS\CssGoToLineProvider.cs" />
+    <Compile Include="Options\Markdown.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Options\UnusedCssOptions.cs">
       <SubType>Component</SubType>
     </Compile>


### PR DESCRIPTION
- Hide/show the preview window.
- Enable save to disk.
- Specify a custom save location.
- Added some default values for the settings dialog (MarkdownOptions), but they seem to be ignored.
- Exposed MarkdownSharp options in the settings dialog:
  - AutoHyperlink
  - LinkEmails
  - AutoNewLines
  - EmptyElementSuffix
  - EncodeProblemUrlCharacters
  - StrictBoldItalic
  - CoffeeScript
- Added property to enable/disable the compiler.
- Added property for custom save location.
  - LESS
- Added property to enable/disable the compiler.
- Updated property for custom save location (hopefully won't conflict with existing settings now).
- Added missing LessSourceMaps property to ProjectSettingsStore; I'm assuming it should be there with the others.
  - Greatly cleaned up the MarginBase.GetCompiledFileName() code by using the ProjectHelpers.GetRootFolder() method. Thanks to @SLaks.
  - Got the compilers (LESS, CoffeeScript, and Markdown) working when there isn't a project loaded and you're just editing one of the files.
  - Upped the version to 1.3.13; I don't know if you want that incremented or not. (Sure makes it easier than un-installing everytime.)
  - TODO Need to figure out how to set defaults, because right now the LESS and CoffeeScript compilers are defaulting to disabled..
