### PR TITLE
Better capturing of region name in JavaScript regions

### DIFF
--- a/EditorExtensions/Classifications/JavaScript/JavaScriptRegionTagger.cs
+++ b/EditorExtensions/Classifications/JavaScript/JavaScriptRegionTagger.cs
@@ -31,7 +31,7 @@ namespace MadsKristensen.EditorExtensions
         ITextBuffer buffer;
         ITextSnapshot snapshot;
         List<Region> regions;
-        private static Regex regex = new Regex(@"\/\/\#region(.*)?", RegexOptions.Compiled);
+        private static Regex regex = new Regex(@"\/\/\ ?\#region(.*)?", RegexOptions.Compiled);
 
         public RegionTagger(ITextBuffer buffer)
         {


### PR DESCRIPTION
This is a fix to a small issue where the region name wouldn't be picked up when the region starts with // #region Name

When there is a space between // and #region, the region collapses (since startHide = "// #region"), however the regex that extracts the name does not allow the space, so when collapsed the region would show "#region" instead of the name. This new regex works with both //#region and // #region.
