### PR TITLE
Setting to skip relative paths fix on css minify

### DIFF
--- a/EditorExtensions/MenuItems/BundleFiles.cs
+++ b/EditorExtensions/MenuItems/BundleFiles.cs
@@ -329,7 +329,8 @@ namespace MadsKristensen.EditorExtensions
                     // If the bundle is in the same folder as the CSS,
                     // or if does not have URLs, no need to normalize.
                     if (Path.GetDirectoryName(file) != Path.GetDirectoryName(bundlePath)
-                     && source.IndexOf("url(", StringComparison.OrdinalIgnoreCase) > 0)
+                     && source.IndexOf("url(", StringComparison.OrdinalIgnoreCase) > 0
+                        && !WESettings.GetBoolean(WESettings.Keys.CssPreserveRelativePathsOnMinify))
                         source = CssUrlNormalizer.NormalizeUrls(
                             tree: new CssParser().Parse(source, true),
                             targetFile: bundlePath,

--- a/EditorExtensions/Options/Css.cs
+++ b/EditorExtensions/Options/Css.cs
@@ -24,6 +24,7 @@ namespace MadsKristensen.EditorExtensions
             Settings.SetValue(WESettings.Keys.ShowBrowserTooltip, ShowBrowserTooltip);
             Settings.SetValue(WESettings.Keys.ValidateZeroUnit, ValidateZeroUnit);
             Settings.SetValue(WESettings.Keys.ValidateVendorSpecifics, ValidateVendorSpecifics);
+            Settings.SetValue(WESettings.Keys.CssPreserveRelativePathsOnMinify, CssPreserveRelativePathsOnMinify);
 
             OnChanged();
             Settings.Save();
@@ -43,6 +44,7 @@ namespace MadsKristensen.EditorExtensions
             ShowBrowserTooltip = WESettings.GetBoolean(WESettings.Keys.ShowBrowserTooltip);
             ValidateZeroUnit = WESettings.GetBoolean(WESettings.Keys.ValidateZeroUnit);
             ValidateVendorSpecifics = WESettings.GetBoolean(WESettings.Keys.ValidateVendorSpecifics);
+            CssPreserveRelativePathsOnMinify = WESettings.GetBoolean(WESettings.Keys.CssPreserveRelativePathsOnMinify);
         }
 
         protected void OnChanged()
@@ -54,6 +56,11 @@ namespace MadsKristensen.EditorExtensions
         [Description("When a .css file (foo.css) is saved and a minified version (foo.min.css) exist, the minified file will be updated. Right-click any .css file to generate .min.css file")]
         [Category("Misc")]
         public bool EnableCssMinification { get; set; }
+
+        [LocDisplayName("Preserve original relative paths in CSS files on minify")]
+        [Description("Deal manually with '../' relative paths. Useful, when resources (e.g. images) are within 'deploy folder', but corresponding css in other developement folder.")]
+        [Category("Misc")]
+        public bool CssPreserveRelativePathsOnMinify { get; set; }
 
         [LocDisplayName("Gzip minified CSS files on save")]
         [Description("When a .css file (foo.css) is saved and a minified version (foo.min.css) exist, a gzipped version of the file will be created.")]

--- a/EditorExtensions/Options/WebEssentialsSettings.cs
+++ b/EditorExtensions/Options/WebEssentialsSettings.cs
@@ -39,6 +39,7 @@ namespace MadsKristensen.EditorExtensions
             public const string ValidateZeroUnit = "CssValidateZeroUnit";
             public const string ValidateVendorSpecifics = "ValidateVendorSpecifics";
             public const string CssEnableGzipping = "CssEnableGzipping";
+            public const string CssPreserveRelativePathsOnMinify = "CssPreserveRelativePathsOnMinify";
 
             // JavaScript
             public const string EnableJsMinification = "JavaScriptEnableMinification";


### PR DESCRIPTION
Sharepoint has virtual "/Layout" folder, so it makes sense to keep there
resources, which are directly "deployed" to the server.
Outside this folder can be development going on, e.g. css-files, which
eventually need to be compiled, minified and so on.
Having enabled css relative paths overwriting on minifying by default
without a setting to turn it off interfere with this folder structure.

Say we have
/Layout/Project1/Styles/fonts/font-awesome.woff
/Layout/Project1/Styles/css/plugins.css.bundle

now, bundle, references file:
/Styles/css/font-awesome.css

now replacing the "../font.woff" to "../../../../font.woff".

The commit is rather simple and merely adds a Misc option to css  bundle
compile check inside
WriteBundleFile,
controlling thus
CssUrlNormalizer.NormalizeUrls

Feel free to commit, or point out why that's unwise, how could we make
this better.
