### PR TITLE
Use ITextDocumentFactoryService to get ITextDocument instances

### DIFF
--- a/EditorExtensions/Classifications/RobotsTxt/RobotsTxtClassifierProvider.cs
+++ b/EditorExtensions/Classifications/RobotsTxt/RobotsTxtClassifierProvider.cs
@@ -19,6 +19,9 @@ namespace MadsKristensen.EditorExtensions
         [Import, System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal IVsEditorAdaptersFactoryService EditorAdaptersFactoryService { get; set; }
 
+        [Import]
+        internal ITextDocumentFactoryService TextDocumentFactoryService { get; set; }
+
         public IClassifier GetClassifier(ITextBuffer textBuffer)
         {
             return textBuffer.Properties.GetOrCreateSingletonProperty<RobotsTxtClassifier>(() => new RobotsTxtClassifier(Registry));
@@ -30,10 +33,8 @@ namespace MadsKristensen.EditorExtensions
             RobotsTxtClassifier classifier;
 
             var view = EditorAdaptersFactoryService.GetWpfTextView(textViewAdapter);
-            view.TextDataModel.DocumentBuffer.Properties.TryGetProperty(typeof(ITextDocument), out document);
-
-            if (document != null)
-            {
+            if (TextDocumentFactoryService.TryGetTextDocument(view.TextDataModel.DocumentBuffer, out document))
+            { 
                 TextType type = GetTextType(document.FilePath);
                 if (type == TextType.Unsupported)
                     return;

--- a/EditorExtensions/Commands/Code/ScriptIntellisenseListener.cs
+++ b/EditorExtensions/Commands/Code/ScriptIntellisenseListener.cs
@@ -21,14 +21,15 @@ namespace MadsKristensen.EditorExtensions
     [TextViewRole(PredefinedTextViewRoles.Document)]
     class ScriptIntellisense : IWpfTextViewCreationListener
     {
+        [Import]
+        internal ITextDocumentFactoryService TextDocumentFactoryService { get; set; }
+
         private ITextDocument _document;
 
         public void TextViewCreated(IWpfTextView textView)
         {
-            textView.TextDataModel.DocumentBuffer.Properties.TryGetProperty(typeof(ITextDocument), out _document);
-
-            if (_document != null)
-            {
+            if (TextDocumentFactoryService.TryGetTextDocument(textView.TextDataModel.DocumentBuffer, out _document))
+            { 
                 _document.FileActionOccurred += document_FileActionOccurred;
             }
         }

--- a/EditorExtensions/Commands/Css/CssSaveListener.cs
+++ b/EditorExtensions/Commands/Css/CssSaveListener.cs
@@ -14,14 +14,15 @@ namespace MadsKristensen.EditorExtensions
     [TextViewRole(PredefinedTextViewRoles.Document)]
     public class CssSaveListener : IWpfTextViewCreationListener
     {
+        [Import]
+        internal ITextDocumentFactoryService TextDocumentFactoryService { get; set; }
+
         private ITextDocument _document;
 
         public void TextViewCreated(IWpfTextView textView)
         {
-            textView.TextDataModel.DocumentBuffer.Properties.TryGetProperty(typeof(ITextDocument), out _document);
-
-            if (_document != null)
-            {
+            if (TextDocumentFactoryService.TryGetTextDocument(textView.TextDataModel.DocumentBuffer, out _document))
+            { 
                 _document.FileActionOccurred += document_FileActionOccurred;
             }
         }

--- a/EditorExtensions/Commands/JavaScript/JavaScriptCreationListener.cs
+++ b/EditorExtensions/Commands/JavaScript/JavaScriptCreationListener.cs
@@ -19,6 +19,9 @@ namespace MadsKristensen.EditorExtensions
         [Import(typeof(ITextStructureNavigatorSelectorService))]
         internal ITextStructureNavigatorSelectorService Navigator { get; set; }
 
+        [Import]
+        internal ITextDocumentFactoryService TextDocumentFactoryService { get; set; }
+
         public void VsTextViewCreated(IVsTextView textViewAdapter)
         {
             var textView = EditorAdaptersFactoryService.GetWpfTextView(textViewAdapter);
@@ -30,9 +33,7 @@ namespace MadsKristensen.EditorExtensions
             textView.Properties.GetOrCreateSingletonProperty<ReferenceTagGoToDefinition>(() => new ReferenceTagGoToDefinition(textViewAdapter, textView));
 
             ITextDocument document;
-            textView.TextDataModel.DocumentBuffer.Properties.TryGetProperty(typeof(ITextDocument), out document);
-
-            if (document != null)
+            if (TextDocumentFactoryService.TryGetTextDocument(textView.TextDataModel.DocumentBuffer, out document))
             {
                 JsHintProjectRunner runner = new JsHintProjectRunner(document);
                 textView.Closed += (s, e) => runner.Dispose();

--- a/EditorExtensions/Commands/JavaScript/JavaScriptSaveListener.cs
+++ b/EditorExtensions/Commands/JavaScript/JavaScriptSaveListener.cs
@@ -15,14 +15,15 @@ namespace MadsKristensen.EditorExtensions
     [TextViewRole(PredefinedTextViewRoles.Document)]
     public class JavaScriptSaveListener : IWpfTextViewCreationListener
     {
+        [Import]
+        internal ITextDocumentFactoryService TextDocumentFactoryService { get; set; }
+
         private ITextDocument _document;
 
         public void TextViewCreated(IWpfTextView textView)
         {
-            textView.TextDataModel.DocumentBuffer.Properties.TryGetProperty(typeof(ITextDocument), out _document);
-
-            if (_document != null)
-            {
+            if (TextDocumentFactoryService.TryGetTextDocument(textView.TextDataModel.DocumentBuffer, out _document))
+            { 
                 _document.FileActionOccurred += document_FileActionOccurred;
             }
         }

--- a/EditorExtensions/Completion/RobotsTxt/RobotsCompletionController.cs
+++ b/EditorExtensions/Completion/RobotsTxt/RobotsCompletionController.cs
@@ -26,16 +26,18 @@ namespace MadsKristensen.EditorExtensions
         [Import]
         ICompletionBroker CompletionBroker = null;
 
+        [Import]
+        ITextDocumentFactoryService TextDocumentFactoryService = null;
+
         public void VsTextViewCreated(IVsTextView textViewAdapter)
         {
             IWpfTextView view = AdaptersFactory.GetWpfTextView(textViewAdapter);
             Debug.Assert(view != null);
 
             ITextDocument document;
-            view.TextDataModel.DocumentBuffer.Properties.TryGetProperty(typeof(ITextDocument), out document);
-
-            if (document == null)
+            if (!TextDocumentFactoryService.TryGetTextDocument(view.TextDataModel.DocumentBuffer, out document))
                 return;
+
             TextType type = RobotsTxtClassifierProvider.GetTextType(document.FilePath);
             if (type == TextType.Unsupported)
                 return;

--- a/EditorExtensions/Margin/EditorMarginFactory.cs
+++ b/EditorExtensions/Margin/EditorMarginFactory.cs
@@ -16,12 +16,15 @@ namespace MadsKristensen.EditorExtensions
     [TextViewRole(PredefinedTextViewRoles.Debuggable)]
     internal sealed class MarginFactory : IWpfTextViewMarginProvider
     {
+        [Import]
+        internal ITextDocumentFactoryService TextDocumentFactoryService { get; set; }
+
         public IWpfTextViewMargin CreateMargin(IWpfTextViewHost textViewHost, IWpfTextViewMargin containerMargin)
         {
             string source = textViewHost.TextView.TextBuffer.CurrentSnapshot.GetText();
             ITextDocument document;
 
-            if (textViewHost.TextView.TextDataModel.DocumentBuffer.Properties.TryGetProperty(typeof(ITextDocument), out document))
+            if (TextDocumentFactoryService.TryGetTextDocument(textViewHost.TextView.TextDataModel.DocumentBuffer, out document))
             {
                 switch (textViewHost.TextView.TextBuffer.ContentType.DisplayName.ToLowerInvariant())
                 {

--- a/EditorExtensions/Options/ProjectSettingsTextViewListener.cs
+++ b/EditorExtensions/Options/ProjectSettingsTextViewListener.cs
@@ -11,12 +11,13 @@ namespace MadsKristensen.EditorExtensions.Options
     [TextViewRole(PredefinedTextViewRoles.Document)]
     internal class ProjectSettingsTextViewListener : IWpfTextViewCreationListener
     {
+        [Import]
+        internal ITextDocumentFactoryService TextDocumentFactoryService { get; set; }
+
         public void TextViewCreated(IWpfTextView textView)
         {
             ITextDocument document;
-            textView.TextDataModel.DocumentBuffer.Properties.TryGetProperty(typeof(ITextDocument), out document);
-
-            if (document != null)
+            if (TextDocumentFactoryService.TryGetTextDocument(textView.TextDataModel.DocumentBuffer, out document))
             {
                 document.FileActionOccurred += document_FileActionOccurred;
             }


### PR DESCRIPTION
This changes the code which maps from ITextBuffer -> ITextDocument to
use ITextDocumentFactoryService instead of directly querying the
property bag.  Querying the property bag works but it's not truly
supported by the Visual Studio team and could be changed at any time.
The ITextDocumentFactoryService interface is the supported method for
getting ITextDocument values.

This is a pretty minor change, it's just something I noticed when I was
looking at the source this morning 
