### PR TITLE
HTML: Only show image tooltips on <img src>

### DIFF
--- a/EditorExtensions/QuickInfo/ImageHtml/ImageQuickInfo.cs
+++ b/EditorExtensions/QuickInfo/ImageHtml/ImageQuickInfo.cs
@@ -28,7 +28,9 @@ namespace MadsKristensen.EditorExtensions
 
             tree.GetPositionElement(point.Value.Position, out node, out attr);
 
-            if (attr == null || (attr.Name != "href" && attr.Name != "src"))
+            if (node == null || !node.Name.Equals("img", StringComparison.OrdinalIgnoreCase))
+                return;
+            if (attr == null || !attr.Name.Equals("src", StringComparison.OrdinalIgnoreCase))
                 return;
 
             string url = ImageQuickInfo.GetFullUrl(attr.Value, session.TextView.TextBuffer);


### PR DESCRIPTION
Fixes #270
