### PR TITLE
Made TypeScript Intellisense correctly process properties of complex types

### DIFF
--- a/EditorExtensions/Commands/Code/IntellisenseWriter.cs
+++ b/EditorExtensions/Commands/Code/IntellisenseWriter.cs
@@ -12,115 +12,103 @@ namespace MadsKristensen.EditorExtensions
 {
     internal class IntellisenseWriter
     {
-        public void Write(IEnumerable<IntellisenseObject> objects, string file)
-        {
+        public void Write( IEnumerable<IntellisenseObject> objects, string file ) {
             StringBuilder sb = new StringBuilder();
 
-            if (Path.GetExtension(file).Equals(".ts", StringComparison.OrdinalIgnoreCase))
-                WriteTypeScript(objects, sb);
+            if ( Path.GetExtension( file ).Equals( ".ts", StringComparison.OrdinalIgnoreCase ) )
+                WriteTypeScript( objects, sb );
             else
-                WriteJavaScript(objects, sb);
+                WriteJavaScript( objects, sb );
 
-            WriteFileToDisk(file, sb);
+            WriteFileToDisk( file, sb );
         }
 
-        private static string CamelCasePropertyName(string name)
-        {
-            if (WESettings.GetBoolean(WESettings.Keys.JavaScriptCamelCasePropertyNames))
-            {
-                name = CamelCase(name);
+        private static string CamelCasePropertyName( string name ) {
+            if ( WESettings.GetBoolean( WESettings.Keys.JavaScriptCamelCasePropertyNames ) ) {
+                name = CamelCase( name );
             }
             return name;
         }
 
-        private static string CamelCaseClassName(string name)
-        {
-            if (WESettings.GetBoolean(WESettings.Keys.JavaScriptCamelCaseClassNames))
-            {
-                name = CamelCase(name);
+        private static string CamelCaseClassName( string name ) {
+            if ( WESettings.GetBoolean( WESettings.Keys.JavaScriptCamelCaseClassNames ) ) {
+                name = CamelCase( name );
             }
             return name;
         }
 
-        private static string CamelCase(string name)
-        {
-            if (string.IsNullOrWhiteSpace(name))
-            {
+        private static string CamelCase( string name ) {
+            if ( string.IsNullOrWhiteSpace( name ) ) {
                 return name;
             }
-            return name[0].ToString(CultureInfo.CurrentCulture).ToLower() + name.Substring(1);
+            return name[0].ToString( CultureInfo.CurrentCulture ).ToLower() + name.Substring( 1 );
         }
 
-        private static void WriteJavaScript(IEnumerable<IntellisenseObject> objects, StringBuilder sb)
-        {
-            sb.AppendLine("var server = server || {};");
+        private static void WriteJavaScript( IEnumerable<IntellisenseObject> objects, StringBuilder sb ) {
+            sb.AppendLine( "var server = server || {};" );
 
-            foreach (IntellisenseObject io in objects)
-            {
-                if (io.IsEnum) continue;
+            foreach ( IntellisenseObject io in objects ) {
+                if ( io.IsEnum ) continue;
 
-                sb.AppendLine("server." + CamelCaseClassName(io.Name) + " = function()  {");
+                sb.AppendLine( "server." + CamelCaseClassName( io.Name ) + " = function()  {" );
 
-                foreach (var p in io.Properties)
-                {
-										string value = p.Type.GetJavaScriptName() + (p.Type.IsArray ? "[]" : "" );
-                    var propertyName = CamelCasePropertyName(p.Name);
+                foreach ( var p in io.Properties ) {
+                    string value = p.Type.GetJavaScriptName() + (p.Type.IsArray ? "[]" : "");
+                    var propertyName = CamelCasePropertyName( p.Name );
                     string comment = p.Summary ?? "The " + propertyName + " property as defined in " + io.FullName;
-                    comment = Regex.Replace(comment, @"\s*[\r\n]+\s*", " ").Trim();
-                    sb.AppendLine("\t/// <field name=\"" + propertyName + "\" type=\"" + value + "\">" +
-                                  SecurityElement.Escape(comment) + "</field>");
-                    sb.AppendLine("\tthis." + propertyName + " = new " + value + "();");
+                    comment = Regex.Replace( comment, @"\s*[\r\n]+\s*", " " ).Trim();
+                    sb.AppendLine( "\t/// <field name=\"" + propertyName + "\" type=\"" + value + "\">" +
+                                  SecurityElement.Escape( comment ) + "</field>" );
+                    sb.AppendLine( "\tthis." + propertyName + " = new " + value + "();" );
                 }
 
-                sb.AppendLine("};");
+                sb.AppendLine( "};" );
                 sb.AppendLine();
             }
         }
 
-        private static void WriteTypeScript(IEnumerable<IntellisenseObject> objects, StringBuilder sb)
-        {
-					foreach ( var ns in objects.GroupBy( o => o.Namespace ) ) {
-						sb.AppendFormat( "declare module {0} {{\r\n", ns.Key );
+        private static void WriteTypeScript( IEnumerable<IntellisenseObject> objects, StringBuilder sb ) {
+            foreach ( var ns in objects.GroupBy( o => o.Namespace ) ) {
+                sb.AppendFormat( "declare module {0} {{\r\n", ns.Key );
 
-						foreach ( IntellisenseObject io in ns ) {
-							if ( io.IsEnum ) {
-								sb.AppendLine( "\tenum " + CamelCaseClassName( io.Name ) + " {" );
-								foreach ( var p in io.Properties ) sb.AppendLine( "\t\t" + CamelCasePropertyName( p.Name ) + "," );
-								sb.AppendLine( "\t}" );
-							}
-							else {
-								sb.Append( "\tinterface " ).Append( CamelCaseClassName( io.Name ) ).Append( " " );
-								WriteTSInterfaceDefinition( sb, "\t", io.Properties );
-								sb.AppendLine();
-							}
-						}
+                foreach ( IntellisenseObject io in ns ) {
+                    if ( io.IsEnum ) {
+                        sb.AppendLine( "\tenum " + CamelCaseClassName( io.Name ) + " {" );
+                        foreach ( var p in io.Properties ) sb.AppendLine( "\t\t" + CamelCasePropertyName( p.Name ) + "," );
+                        sb.AppendLine( "\t}" );
+                    }
+                    else {
+                        sb.Append( "\tinterface " ).Append( CamelCaseClassName( io.Name ) ).Append( " " );
+                        WriteTSInterfaceDefinition( sb, "\t", io.Properties );
+                        sb.AppendLine();
+                    }
+                }
 
-						sb.AppendLine( "}" );
-					}
+                sb.AppendLine( "}" );
+            }
         }
 
-				private static void WriteTSInterfaceDefinition( StringBuilder sb, string prefix, IEnumerable<IntellisenseProperty> props ) {
-					sb.AppendLine( "{" );
-					
-					foreach ( var p in props ) {
-						sb.AppendFormat( "{0}\t{1}: ", prefix, CamelCasePropertyName( p.Name ) );
-						
-						if ( p.Type.IsPrimitive() ) sb.Append( p.Type.GetTypeScriptName() );
-						else if ( !string.IsNullOrEmpty( p.Type.ClientSideReferenceName ) ) sb.Append( p.Type.ClientSideReferenceName );
-						else {
-							if ( p.Type.Shape == null ) sb.Append( "any" );
-							else WriteTSInterfaceDefinition( sb, prefix + "\t", p.Type.Shape );
-							}
-						if ( p.Type.IsArray ) sb.Append( "[]" );
+        private static void WriteTSInterfaceDefinition( StringBuilder sb, string prefix, IEnumerable<IntellisenseProperty> props ) {
+            sb.AppendLine( "{" );
 
-						sb.AppendLine( ";" );
-						}
+            foreach ( var p in props ) {
+                sb.AppendFormat( "{0}\t{1}: ", prefix, CamelCasePropertyName( p.Name ) );
 
-					sb.Append( prefix ).Append( "}" );
+                if ( p.Type.IsPrimitive() ) sb.Append( p.Type.GetTypeScriptName() );
+                else if ( !string.IsNullOrEmpty( p.Type.ClientSideReferenceName ) ) sb.Append( p.Type.ClientSideReferenceName );
+                else {
+                    if ( p.Type.Shape == null ) sb.Append( "any" );
+                    else WriteTSInterfaceDefinition( sb, prefix + "\t", p.Type.Shape );
+                }
+                if ( p.Type.IsArray ) sb.Append( "[]" );
+
+                sb.AppendLine( ";" );
+            }
+
+            sb.Append( prefix ).Append( "}" );
         }
 
-        private static void WriteFileToDisk(string fileName, StringBuilder sb)
-        {
+        private static void WriteFileToDisk( string fileName, StringBuilder sb ) {
             //string current = string.Empty;
             //if (File.Exists(fileName))
             //{
@@ -129,7 +117,7 @@ namespace MadsKristensen.EditorExtensions
 
             //if (current != sb.ToString())
             //{
-            File.WriteAllText(fileName, sb.ToString());
+            File.WriteAllText( fileName, sb.ToString() );
             //}
         }
     }
@@ -139,74 +127,74 @@ namespace MadsKristensen.EditorExtensions
         public string Namespace { get; set; }
         public string Name { get; set; }
         public string FullName { get; set; }
-				public bool IsEnum { get; set; }
+        public bool IsEnum { get; set; }
         public List<IntellisenseProperty> Properties { get; set; }
-		}
+    }
 
     public class IntellisenseProperty
     {
         public string Name { get; set; }
-				public IntellisenseType Type { get; set; }
+        public IntellisenseType Type { get; set; }
         public string Summary { get; set; }
     }
 
-		public class IntellisenseType
-            {
-			/// <summary>
-			/// This is the name of this type as it appears in the source code
-			/// </summary>
-			public string CodeName { get; set; }
+    public class IntellisenseType
+    {
+        /// <summary>
+        /// This is the name of this type as it appears in the source code
+        /// </summary>
+        public string CodeName { get; set; }
 
-			/// <summary>
-			/// Indicates whether this type is array. Is this property is true, then all other properties
-			/// describe not the type itself, but rather the type of the array's elements.
-			/// </summary>
-			public bool IsArray { get; set; }
+        /// <summary>
+        /// Indicates whether this type is array. Is this property is true, then all other properties
+        /// describe not the type itself, but rather the type of the array's elements.
+        /// </summary>
+        public bool IsArray { get; set; }
 
-			/// <summary>
-			/// If this type is itself part of a source code file that has a .d.ts definitions file attached,
-			/// this property will contain the full (namespace-qualified) client-side name of that type.
-			/// Otherwise, this property is null.
-			/// </summary>
-			public string ClientSideReferenceName { get; set; }
+        /// <summary>
+        /// If this type is itself part of a source code file that has a .d.ts definitions file attached,
+        /// this property will contain the full (namespace-qualified) client-side name of that type.
+        /// Otherwise, this property is null.
+        /// </summary>
+        public string ClientSideReferenceName { get; set; }
 
-			/// <summary>
-			/// This is TypeScript-formed shape of the type (i.e. inline type definition). It is used for the case where
-			/// the type is not primitive, but does not have its own named client-side definition.
-			/// </summary>
-			public IEnumerable<IntellisenseProperty> Shape { get; set; }
+        /// <summary>
+        /// This is TypeScript-formed shape of the type (i.e. inline type definition). It is used for the case where
+        /// the type is not primitive, but does not have its own named client-side definition.
+        /// </summary>
+        public IEnumerable<IntellisenseProperty> Shape { get; set; }
 
-			public bool IsPrimitive() { return GetTypeScriptName() != "any"; }
-			public string GetJavaScriptName() { return GetTargetName( true ); }
-			public string GetTypeScriptName() { return GetTargetName( false ); }
+        public bool IsPrimitive() { return GetTypeScriptName() != "any"; }
+        public string GetJavaScriptName() { return GetTargetName( true ); }
+        public string GetTypeScriptName() { return GetTargetName( false ); }
 
-			string GetTargetName( bool js ) {
-				var t = CodeName.ToLower();
-				switch ( t ) {
-					case "int":
-					case "int32":
-					case "int64":
-					case "long":
-					case "double":
-					case "float":
-					case "decimal":
-						return js ? "Number" : "number";
+        string GetTargetName( bool js ) {
+            var t = CodeName.ToLower();
+            switch ( t ) {
+                case "int":
+                case "int32":
+                case "int64":
+                case "long":
+                case "double":
+                case "float":
+                case "decimal":
+                    return js ? "Number" : "number";
 
-					case "system.datetime":
-						return "Date";
+                case "system.datetime":
+                    return "Date";
 
-					case "string":
-						return js ? "String" : "string";
+                case "string":
+                    return js ? "String" : "string";
 
-					case "bool":
-					case "boolean":
-						return js ? "Boolean" : "boolean";
-				}
+                case "bool":
+                case "boolean":
+                    return js ? "Boolean" : "boolean";
+            }
 
-				if ( t.Contains( "system.collections" ) || t.Contains( "[]" ) || t.Contains( "array" ) )
-					return "Array";
+            if ( t.Contains( "system.collections" ) || t.Contains( "[]" ) || t.Contains( "array" ) )
+                return "Array";
 
-				return js ? "Object" : "any";
-			}
+            return js ? "Object" : "any";
+        }
     }
 }

--- a/EditorExtensions/Commands/Code/ScriptIntellisenseListener.cs
+++ b/EditorExtensions/Commands/Code/ScriptIntellisenseListener.cs
@@ -15,123 +15,113 @@ using EnvDTE80;
 
 namespace MadsKristensen.EditorExtensions
 {
-    [Export(typeof (IWpfTextViewCreationListener))]
-    [ContentType("CSharp")]
-    [ContentType("VisualBasic")]
-    [TextViewRole(PredefinedTextViewRoles.Document)]
+    [Export( typeof( IWpfTextViewCreationListener ) )]
+    [ContentType( "CSharp" )]
+    [ContentType( "VisualBasic" )]
+    [TextViewRole( PredefinedTextViewRoles.Document )]
     internal class ScriptIntellisense : IWpfTextViewCreationListener
     {
-			public const string DefaultModuleName = "server";
-			public const string ModuleNameAttributeName = "TypeScriptModule";
+        public const string DefaultModuleName = "server";
+        public const string ModuleNameAttributeName = "TypeScriptModule";
 
-			static class Ext
-			{
-				public const string JavaScript = ".js";
-				public const string TypeScript = ".d.ts";
-			}
+        static class Ext
+        {
+            public const string JavaScript = ".js";
+            public const string TypeScript = ".d.ts";
+        }
 
         [Import]
         internal ITextDocumentFactoryService TextDocumentFactoryService { get; set; }
 
         private ITextDocument _document;
 
-        public void TextViewCreated(IWpfTextView textView)
-        {
-            if (TextDocumentFactoryService.TryGetTextDocument(textView.TextDataModel.DocumentBuffer, out _document))
-            { 
+        public void TextViewCreated( IWpfTextView textView ) {
+            if ( TextDocumentFactoryService.TryGetTextDocument( textView.TextDataModel.DocumentBuffer, out _document ) ) {
                 _document.FileActionOccurred += document_FileActionOccurred;
             }
         }
 
-        private void document_FileActionOccurred(object sender, TextDocumentFileActionEventArgs e)
-        {
-            ITextDocument document = (ITextDocument) sender;
+        private void document_FileActionOccurred( object sender, TextDocumentFileActionEventArgs e ) {
+            ITextDocument document = (ITextDocument)sender;
 
-            if (document.TextBuffer == null || e.FileActionType != FileActionTypes.ContentSavedToDisk)
+            if ( document.TextBuffer == null || e.FileActionType != FileActionTypes.ContentSavedToDisk )
                 return;
 
-            Process(e.FilePath);
+            Process( e.FilePath );
         }
 
-        public static void Process(string filePath)
-        {
-            if (!File.Exists(filePath + Ext.JavaScript) && !File.Exists(filePath + Ext.TypeScript))
+        public static void Process( string filePath ) {
+            if ( !File.Exists( filePath + Ext.JavaScript ) && !File.Exists( filePath + Ext.TypeScript ) )
                 return;
 
-            Dispatcher.CurrentDispatcher.BeginInvoke(new Action(() =>
-            {
-                var item = EditorExtensionsPackage.DTE.Solution.FindProjectItem(filePath);
-                var list = ProcessFile(item);
+            Dispatcher.CurrentDispatcher.BeginInvoke( new Action( () => {
+                var item = EditorExtensionsPackage.DTE.Solution.FindProjectItem( filePath );
+                var list = ProcessFile( item );
 
-                if (list != null)
-                {
-                    AddScript(filePath, Ext.JavaScript, list);
-                    AddScript(filePath, Ext.TypeScript, list);
+                if ( list != null ) {
+                    AddScript( filePath, Ext.JavaScript, list );
+                    AddScript( filePath, Ext.TypeScript, list );
                 }
-            }), DispatcherPriority.ApplicationIdle, null);
+            } ), DispatcherPriority.ApplicationIdle, null );
         }
 
-        private static void AddScript(string filePath, string extension, List<IntellisenseObject> list)
-        {
+        private static void AddScript( string filePath, string extension, List<IntellisenseObject> list ) {
             string resultPath = filePath + extension;
 
-            if (!File.Exists(resultPath))
+            if ( !File.Exists( resultPath ) )
                 return;
 
             IntellisenseWriter writer = new IntellisenseWriter();
-            writer.Write(list, resultPath);
-            var item = MarginBase.AddFileToProject(filePath, resultPath);
+            writer.Write( list, resultPath );
+            var item = MarginBase.AddFileToProject( filePath, resultPath );
 
-            if (extension.Equals(Ext.TypeScript, StringComparison.OrdinalIgnoreCase))
-                item.Properties.Item("ItemType").Value = "TypeScriptCompile";
-            else
-            {
-                item.Properties.Item("ItemType").Value = "None";
+            if ( extension.Equals( Ext.TypeScript, StringComparison.OrdinalIgnoreCase ) )
+                item.Properties.Item( "ItemType" ).Value = "TypeScriptCompile";
+            else {
+                item.Properties.Item( "ItemType" ).Value = "None";
             }
         }
 
-				private static List<IntellisenseObject> ProcessFile( ProjectItem item ) {
-					if ( item.FileCodeModel == null )
-						return null;
+        private static List<IntellisenseObject> ProcessFile( ProjectItem item ) {
+            if ( item.FileCodeModel == null )
+                return null;
 
-					List<IntellisenseObject> list = new List<IntellisenseObject>();
+            List<IntellisenseObject> list = new List<IntellisenseObject>();
 
-					foreach ( CodeElement element in item.FileCodeModel.CodeElements ) {
-						if ( element.Kind == vsCMElement.vsCMElementNamespace ) {
-							CodeNamespace cn = (CodeNamespace)element;
-							foreach ( CodeElement member in cn.Members ) {
-								if ( ShouldProcess( member ) ) {
-									ProcessElement( member, list );
-								}
-							}
-						}
-						else if ( ShouldProcess( element ) ) {
-							ProcessElement( element, list );
-						}
-					}
+            foreach ( CodeElement element in item.FileCodeModel.CodeElements ) {
+                if ( element.Kind == vsCMElement.vsCMElementNamespace ) {
+                    CodeNamespace cn = (CodeNamespace)element;
+                    foreach ( CodeElement member in cn.Members ) {
+                        if ( ShouldProcess( member ) ) {
+                            ProcessElement( member, list );
+                        }
+                    }
+                }
+                else if ( ShouldProcess( element ) ) {
+                    ProcessElement( element, list );
+                }
+            }
 
-					return list;
-				}
+            return list;
+        }
 
-				private static void ProcessElement( CodeElement element, List<IntellisenseObject> list ) {
-					if ( element.Kind == vsCMElement.vsCMElementEnum ) {
-						ProcessEnum( (CodeEnum)element, list );
-					}
-					else if ( element.Kind == vsCMElement.vsCMElementClass ) {
-						ProcessClass( (CodeClass)element, list );
-					}
-				}
+        private static void ProcessElement( CodeElement element, List<IntellisenseObject> list ) {
+            if ( element.Kind == vsCMElement.vsCMElementEnum ) {
+                ProcessEnum( (CodeEnum)element, list );
+            }
+            else if ( element.Kind == vsCMElement.vsCMElementClass ) {
+                ProcessClass( (CodeClass)element, list );
+            }
+        }
 
-				private static bool ShouldProcess( CodeElement member ) {
-					return
-							member.Kind == vsCMElement.vsCMElementClass
-							|| member.Kind == vsCMElement.vsCMElementEnum;
-				}
+        private static bool ShouldProcess( CodeElement member ) {
+            return
+                    member.Kind == vsCMElement.vsCMElementClass
+                    || member.Kind == vsCMElement.vsCMElementEnum;
+        }
 
-        private static void ProcessEnum(CodeEnum element, List<IntellisenseObject> list)
-        {
-            IntellisenseObject data = new IntellisenseObject
-            {
+        private static void ProcessEnum( CodeEnum element, List<IntellisenseObject> list ) {
+            IntellisenseObject data = new IntellisenseObject {
                 Name = element.Name,
                 IsEnum = element.Kind == vsCMElement.vsCMElementEnum,
                 FullName = element.FullName,
@@ -139,132 +129,123 @@ namespace MadsKristensen.EditorExtensions
                 Namespace = GetNamespace( element ),
             };
 
-            foreach (var codeEnum in element.Members.OfType<CodeElement>())
-            {
-                var prop = new IntellisenseProperty()
-                {
+            foreach ( var codeEnum in element.Members.OfType<CodeElement>() ) {
+                var prop = new IntellisenseProperty() {
                     Name = codeEnum.Name,
                 };
 
-                data.Properties.Add(prop);
+                data.Properties.Add( prop );
             }
 
-            if (data.Properties.Count > 0)
-                list.Add(data);
+            if ( data.Properties.Count > 0 )
+                list.Add( data );
         }
 
-        private static void ProcessClass(CodeClass cc, List<IntellisenseObject> list)
-        {
-					var props = GetProperties( cc.Members, new HashSet<string>() ).ToList();
-					if ( props.Any() ) list.Add( new IntellisenseObject
-            {
+        private static void ProcessClass( CodeClass cc, List<IntellisenseObject> list ) {
+            var props = GetProperties( cc.Members, new HashSet<string>() ).ToList();
+            if ( props.Any() ) list.Add( new IntellisenseObject {
                 Namespace = GetNamespace( cc ),
                 Name = cc.Name,
                 FullName = cc.FullName,
-								Properties = props
+                Properties = props
             } );
         }
 
-				private static IEnumerable<IntellisenseProperty> GetProperties( CodeElements props, HashSet<string> traversedTypes ) {
-					return from p in props.OfType<CodeProperty>()
-								 where !p.Attributes.Cast<CodeAttribute>().Any( a => a.Name == "IgnoreDataMember" )
-								 where p.Getter != null && !p.Getter.IsShared && p.Getter.Access == vsCMAccess.vsCMAccessPublic
-								 select new IntellisenseProperty() {
-									 Name = GetName( p ),
-									 Type = GetType( p.Type, traversedTypes ),
-									 Summary = GetSummary( p )
-								 };
-				}
-
-				private static string GetNamespace( CodeClass e ) { return GetNamespace( e.Attributes ); }
-				private static string GetNamespace( CodeEnum e ) { return GetNamespace( e.Attributes ); }
-
-				private static string GetNamespace( CodeElements attrs ) {
-					if ( attrs == null ) return DefaultModuleName;
-					var namespaceFromAttr = from a in attrs.Cast<CodeAttribute2>()
-																	where a.Name.EndsWith( ModuleNameAttributeName, StringComparison.InvariantCultureIgnoreCase )
-																	from arg in a.Arguments.Cast<CodeAttributeArgument>()
-																	let v = (arg.Value ?? "").Trim( '\"' )
-																	where !string.IsNullOrWhiteSpace( v )
-																	select v;
-					
-					return namespaceFromAttr.FirstOrDefault() ?? DefaultModuleName;
-				}
-
-				private static IntellisenseType GetType( CodeTypeRef codeTypeRef, HashSet<string> traversedTypes ) {
-					var isArray = codeTypeRef.TypeKind == vsCMTypeRef.vsCMTypeRefArray;
-					if ( isArray && codeTypeRef.ElementType != null ) codeTypeRef = codeTypeRef.ElementType;
-
-					var cl = codeTypeRef.CodeType as CodeClass;
-					var en = codeTypeRef.CodeType as CodeEnum;
-					var isPrimitive = IsPrimitive( codeTypeRef );
-					var result = new IntellisenseType {
-						IsArray = isArray,
-						CodeName = codeTypeRef.AsString,
-						ClientSideReferenceName =
-							codeTypeRef.TypeKind == vsCMTypeRef.vsCMTypeRefCodeType &&
-							codeTypeRef.CodeType.InfoLocation == vsCMInfoLocation.vsCMInfoLocationProject
-							?
-								(cl != null && HasIntellisense( cl.ProjectItem, Ext.TypeScript ) ? (GetNamespace( cl ) + "." + cl.Name) : null) ??
-								(en != null && HasIntellisense( en.ProjectItem, Ext.TypeScript ) ? (GetNamespace( en ) + "." + en.Name) : null)
-							: null
-					};
-
-					if ( !isPrimitive && cl != null && !traversedTypes.Contains( codeTypeRef.CodeType.FullName ) ) {
-						traversedTypes.Add( codeTypeRef.CodeType.FullName );
-						result.Shape = GetProperties( codeTypeRef.CodeType.Members, traversedTypes ).ToList();
-						traversedTypes.Remove( codeTypeRef.CodeType.FullName );
-					}
-
-					return result;
-				}
-
-				private static bool IsPrimitive( CodeTypeRef codeTypeRef ) {
-					if ( codeTypeRef.TypeKind != vsCMTypeRef.vsCMTypeRefOther && codeTypeRef.TypeKind != vsCMTypeRef.vsCMTypeRefCodeType ) return true;
-					if ( codeTypeRef.AsString.EndsWith( "DateTime" ) ) return true;
-					return false;
-            }
-
-				private static bool HasIntellisense( ProjectItem projectItem, string ext ) {
-					for ( short i = 0; i < projectItem.FileCount; i++ ) {
-						if ( File.Exists( projectItem.FileNames[i] + ext ) ) return true;
-					}
-					return false;
+        private static IEnumerable<IntellisenseProperty> GetProperties( CodeElements props, HashSet<string> traversedTypes ) {
+            return from p in props.OfType<CodeProperty>()
+                   where !p.Attributes.Cast<CodeAttribute>().Any( a => a.Name == "IgnoreDataMember" )
+                   where p.Getter != null && !p.Getter.IsShared && p.Getter.Access == vsCMAccess.vsCMAccessPublic
+                   select new IntellisenseProperty() {
+                       Name = GetName( p ),
+                       Type = GetType( p.Type, traversedTypes ),
+                       Summary = GetSummary( p )
+                   };
         }
 
-        private static string GetName(CodeProperty property)
-        {
-            foreach (CodeAttribute attr in property.Attributes)
-            {
-                if (attr.Name != "DataMember" && !attr.Name.EndsWith(".DataMember"))
+        private static string GetNamespace( CodeClass e ) { return GetNamespace( e.Attributes ); }
+        private static string GetNamespace( CodeEnum e ) { return GetNamespace( e.Attributes ); }
+
+        private static string GetNamespace( CodeElements attrs ) {
+            if ( attrs == null ) return DefaultModuleName;
+            var namespaceFromAttr = from a in attrs.Cast<CodeAttribute2>()
+                                    where a.Name.EndsWith( ModuleNameAttributeName, StringComparison.InvariantCultureIgnoreCase )
+                                    from arg in a.Arguments.Cast<CodeAttributeArgument>()
+                                    let v = (arg.Value ?? "").Trim( '\"' )
+                                    where !string.IsNullOrWhiteSpace( v )
+                                    select v;
+
+            return namespaceFromAttr.FirstOrDefault() ?? DefaultModuleName;
+        }
+
+        private static IntellisenseType GetType( CodeTypeRef codeTypeRef, HashSet<string> traversedTypes ) {
+            var isArray = codeTypeRef.TypeKind == vsCMTypeRef.vsCMTypeRefArray;
+            if ( isArray && codeTypeRef.ElementType != null ) codeTypeRef = codeTypeRef.ElementType;
+
+            var cl = codeTypeRef.CodeType as CodeClass;
+            var en = codeTypeRef.CodeType as CodeEnum;
+            var isPrimitive = IsPrimitive( codeTypeRef );
+            var result = new IntellisenseType {
+                IsArray = isArray,
+                CodeName = codeTypeRef.AsString,
+                ClientSideReferenceName =
+                    codeTypeRef.TypeKind == vsCMTypeRef.vsCMTypeRefCodeType &&
+                    codeTypeRef.CodeType.InfoLocation == vsCMInfoLocation.vsCMInfoLocationProject
+                    ?
+                        (cl != null && HasIntellisense( cl.ProjectItem, Ext.TypeScript ) ? (GetNamespace( cl ) + "." + cl.Name) : null) ??
+                        (en != null && HasIntellisense( en.ProjectItem, Ext.TypeScript ) ? (GetNamespace( en ) + "." + en.Name) : null)
+                    : null
+            };
+
+            if ( !isPrimitive && cl != null && !traversedTypes.Contains( codeTypeRef.CodeType.FullName ) ) {
+                traversedTypes.Add( codeTypeRef.CodeType.FullName );
+                result.Shape = GetProperties( codeTypeRef.CodeType.Members, traversedTypes ).ToList();
+                traversedTypes.Remove( codeTypeRef.CodeType.FullName );
+            }
+
+            return result;
+        }
+
+        private static bool IsPrimitive( CodeTypeRef codeTypeRef ) {
+            if ( codeTypeRef.TypeKind != vsCMTypeRef.vsCMTypeRefOther && codeTypeRef.TypeKind != vsCMTypeRef.vsCMTypeRefCodeType ) return true;
+            if ( codeTypeRef.AsString.EndsWith( "DateTime" ) ) return true;
+            return false;
+        }
+
+        private static bool HasIntellisense( ProjectItem projectItem, string ext ) {
+            for ( short i = 0; i < projectItem.FileCount; i++ ) {
+                if ( File.Exists( projectItem.FileNames[i] + ext ) ) return true;
+            }
+            return false;
+        }
+
+        private static string GetName( CodeProperty property ) {
+            foreach ( CodeAttribute attr in property.Attributes ) {
+                if ( attr.Name != "DataMember" && !attr.Name.EndsWith( ".DataMember" ) )
                     continue;
 
-                var value = attr.Children.OfType<CodeAttributeArgument>().FirstOrDefault(p => p.Name == "Name");
+                var value = attr.Children.OfType<CodeAttributeArgument>().FirstOrDefault( p => p.Name == "Name" );
 
-                if (value == null)
+                if ( value == null )
                     break;
                 // Strip the leading & trailing quotes
-                return value.Value.Substring(1, value.Value.Length - 2);
+                return value.Value.Substring( 1, value.Value.Length - 2 );
             }
 
             return property.Name;
         }
 
-        private static string GetSummary(CodeProperty property)
-        {
-            if (property.InfoLocation != vsCMInfoLocation.vsCMInfoLocationProject || string.IsNullOrWhiteSpace(property.DocComment))
+        private static string GetSummary( CodeProperty property ) {
+            if ( property.InfoLocation != vsCMInfoLocation.vsCMInfoLocationProject || string.IsNullOrWhiteSpace( property.DocComment ) )
                 return null;
 
-            try
-            {
-                return XElement.Parse(property.DocComment)
-                               .Descendants("summary")
-                               .Select(x => x.Value)
+            try {
+                return XElement.Parse( property.DocComment )
+                               .Descendants( "summary" )
+                               .Select( x => x.Value )
                                .FirstOrDefault();
             }
-            catch (Exception ex)
-            {
-                Logger.Log("Couldn't parse XML Doc Comment for " + property.FullName + ":\n" + ex);
+            catch ( Exception ex ) {
+                Logger.Log( "Couldn't parse XML Doc Comment for " + property.FullName + ":\n" + ex );
                 return null;
             }
         }


### PR DESCRIPTION
Made TypeScript Intellisense correctly process properties of complex types: rather than just generate "Object", the IntellisenseWriter now appropriately specifies the target type. In particular:
- If the property type is a primitive, string, or DateTime, then it is translated as before - to either Number, String, Boolean, or Date.
- If the type is a fellow TypeScript-facing class or enum (i.e. also has a generated .d.ts file), then the full TypeScript-side name of that type is used.
- Otherwise, an inline TypeScript interface definition is generated, recursively applying these rules to all sub-properties of the type.
- The previous rule doesn't apply to enums. If a property has the type of a non-TypeScript-facing enum, it is rendered as "any".
- If a type reference cycle is encountered while generating the inline interface definition (i.e. some type in the hierarchy references itself either directly or through other types), then the inline type is generated down to the first repetition of the cycle, at which point the type is rendered as "any".
- Static and non-public properties are ignored.
### For example:
#### Source:

```
public class A {
   public string X { get; set; }
   public int Y { get; set; }
}

public class B {
   public string P { get; set; }
   public A Q { get; set; }  // Fellow TypeScript-facing class A
   public Tuple<int,string> R { get; set; }
}
```
#### Result:

```
declare module server {
    interface A {
        X: string;
        Y: number;
    }
    interface B {
        P: string;
        Q: server.A;
        R: {
            Item1: number;
            Item2: string;
        };
    }
}
```
