### PR TITLE
Analysis: (CA1012) Abstract type has constructor.

### DIFF
--- a/EditorExtensions/Helpers/TabAwareCharacterStream.cs
+++ b/EditorExtensions/Helpers/TabAwareCharacterStream.cs
@@ -159,7 +159,7 @@ namespace MadsKristensen.EditorExtensions.Helpers
         protected readonly TabAwareCharacterStream stream;
         private bool shouldRevert = true;
 
-        public StreamPeeker(TabAwareCharacterStream stream)
+        protected StreamPeeker(TabAwareCharacterStream stream)
         {
             this.stream = stream;
             StartPosition = stream.Position;


### PR DESCRIPTION
Fixes [CA1012](http://msdn.microsoft.com/en-us/library/ms182126.aspx) warning. 
