### PR TITLE
Adding start of media query validation to give more informative error messages

### DIFF
--- a/EditorExtensions/Validation/CSS/Providers/MediaQuerySyntaxErrorTagProvider.cs
+++ b/EditorExtensions/Validation/CSS/Providers/MediaQuerySyntaxErrorTagProvider.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.CSS.Core;
+using Microsoft.VisualStudio.Utilities;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Globalization;
+
+namespace MadsKristensen.EditorExtensions.Validation.CSS.Providers
+{
+    [Export(typeof(ICssItemChecker))]
+    [Name("MediaQuerySyntaxErrorTagProvider")]
+    [Order(After = "Default Declaration")]
+    internal class MediaQuerySyntaxErrorTagProvider : ICssItemChecker
+    {
+        private const string _orInvalidMessage = "Validation: CSS media queries uses ',' as a logical or operation.";
+        public ItemCheckResult CheckItem(ParseItem item, ICssCheckerContext context)
+        {
+            if (item.IsValid)
+                return ItemCheckResult.Continue;
+
+            if (item.Text.Contains(" or "))
+            {
+                ICssError tag = new SimpleErrorTag(item, _orInvalidMessage);
+                context.AddError(tag);
+                return ItemCheckResult.CancelCurrentItem;
+            }
+
+            return ItemCheckResult.Continue;
+        }
+
+        public IEnumerable<Type> ItemTypes
+        {
+            get { return new[] { typeof(MediaQuery) }; }
+        }
+    }
+}

--- a/EditorExtensions/WebEssentials2013.csproj
+++ b/EditorExtensions/WebEssentials2013.csproj
@@ -494,6 +494,7 @@
     <Compile Include="SmartTags\HTML\HtmlRemoveParentSmartTag.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Validation\CSS\Providers\MediaQuerySyntaxErrorTagProvider.cs" />
     <Compile Include="Validation\CSS\Providers\UnusedCssTagProvider.cs" />
     <Compile Include="Validation\HTML\BootstrapClassValidator.cs" />
     <Compile Include="Validation\HTML\AngularMissingAppValidator.cs" />


### PR DESCRIPTION
I'm just learning media query syntax and when you have an error in the syntax VS isn't particularly helpful as to what the problem is.

I had this:

```
@media (max-width: 640px) or (max-device-width: 640px)
```

And it will tell you that `or` isn't valid but it was off to the internet to work out what the correct syntax is. This TagProvider will inject a message to help you out instead.
