### PR TITLE
Make Css NavigateTo cancellable

### DIFF
--- a/EditorExtensions/NavigateTo/CSS/CSSGoToLineProvider.cs
+++ b/EditorExtensions/NavigateTo/CSS/CSSGoToLineProvider.cs
@@ -1,17 +1,139 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CSS.Core;
 using Microsoft.VisualStudio.Language.NavigateTo.Interfaces;
 using Microsoft.VisualStudio.PlatformUI;
+using System.Threading;
 
 namespace MadsKristensen.EditorExtensions
 {
     internal sealed class CssGoToLineProvider : DisposableObject, INavigateToItemProvider
     {
+        private sealed class Worker
+        {
+            private readonly CssGoToLineProviderFactory _providerFactory;
+            private readonly CancellationTokenSource _cancellationTokenSource;
+            private readonly CancellationToken _cancellationToken;
+            private readonly INavigateToCallback _navigateToCallback;
+            private readonly string _searchValue;
+            private int _backgroundProgress;
+
+            internal Worker(CssGoToLineProviderFactory providerFactory, INavigateToCallback navigateToCallback, string searchValue)
+            {
+                _providerFactory = providerFactory;
+                _searchValue = searchValue;
+                _navigateToCallback = navigateToCallback;
+                _cancellationTokenSource = new CancellationTokenSource();
+                _cancellationToken = _cancellationTokenSource.Token;
+
+                ThreadPool.QueueUserWorkItem(DoWork, null);
+            }
+
+            internal void Cancel()
+            {
+                _cancellationTokenSource.Cancel();
+            }
+
+            private void DoWork(object unused)
+            {
+                try
+                {
+                    var fileList = GetFiles();
+                    var parallelOptions = new ParallelOptions();
+                    parallelOptions.CancellationToken = _cancellationToken;
+                    parallelOptions.MaxDegreeOfParallelism = Environment.ProcessorCount;
+
+                    Parallel.For(0, fileList.Count, parallelOptions, i =>
+                    {
+                        string file = fileList[i];
+                        IEnumerable<ParseItem> items = GetItems(file, _searchValue);
+                        foreach (ParseItem sel in items)
+                        {
+                            _cancellationToken.ThrowIfCancellationRequested();
+                            _navigateToCallback.AddItem(new NavigateToItem(_searchValue, NavigateToItemKind.Field, "CSS", _searchValue, new CssGoToLineTag(sel, file), MatchKind.Exact, _providerFactory));
+                        }
+
+                        var backgroundProgress = Interlocked.Increment(ref _backgroundProgress);
+                        _navigateToCallback.ReportProgress(backgroundProgress, fileList.Count);
+                    });
+                }
+                catch
+                {
+                    // Don't let exceptions from the background thread reach the ThreadPool.  Swallow them
+                    // here and complete the navigate operation
+                }
+                finally
+                {
+                    _navigateToCallback.Done();
+                }
+            }
+
+            private static IEnumerable<ParseItem> GetItems(string filePath, string searchValue)
+            {
+                var cssParser = new CssParser();
+                StyleSheet ss = cssParser.Parse(File.ReadAllText(filePath), true);
+
+                return new CssItemAggregator<ParseItem>
+                {
+                    (ClassSelector c) => c.Text.Contains(searchValue) ? c : null,
+                    (IdSelector c) => c.Text.Contains(searchValue) ? c : null
+                }.Crawl(ss).Where(s => s != null);
+            }
+
+            private static List<string> GetFiles()
+            {
+                var projectFolderPath = GetProjectFolderPath();
+                var fileList = new List<string>();
+                if (string.IsNullOrEmpty(projectFolderPath))
+                    return fileList;
+
+                fileList.AddRange(Directory.GetFiles(projectFolderPath, "*.less", SearchOption.AllDirectories));
+                fileList.AddRange(Directory.GetFiles(projectFolderPath, "*.css", SearchOption.AllDirectories));
+
+                return fileList.Where(filePath => !IsPathIgnoredBySearch(filePath)).ToList();
+            }
+
+            private static bool IsPathIgnoredBySearch(string path)
+            {
+                return
+                    path.IndexOf(".min.", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    path.IndexOf(".bundle.", StringComparison.OrdinalIgnoreCase) >= 0;
+            }
+
+            /// <summary>
+            /// This method will get the folder for the current project.  This will limit the search to the 
+            /// current project which is unfortunate.  Should probably extend this to include all projects
+            /// in the solution at some point
+            /// </summary>
+            /// 
+            /// <remarks>
+            /// Note that this method is always called on a background thread of Visual Studio.  Yet it is
+            /// issuing queries to several DTE objects.  All DTE objects are really STA COM objects meaning
+            /// that this method ends up running a bit of code on the UI thread of Visual Studio via 
+            /// COM marshalling.  It would probably be best if we just ran this one time and cached the
+            /// result but for now it doesn't cause a significant delay so not adding the caching overhead
+            /// </remarks>
+            private static string GetProjectFolderPath()
+            {
+                string folder = ProjectHelpers.GetRootFolder();
+
+                if (string.IsNullOrEmpty(folder))
+                {
+                    var doc = EditorExtensionsPackage.DTE.ActiveDocument;
+                    if (doc != null)
+                        folder = ProjectHelpers.GetProjectFolder(EditorExtensionsPackage.DTE.ActiveDocument.FullName);
+                }
+
+                return folder;
+            }
+        }
+
         private readonly CssGoToLineProviderFactory _owner;
+        private Worker _currentWorker;
 
         public CssGoToLineProvider(CssGoToLineProviderFactory owner)
         {
@@ -20,42 +142,13 @@ namespace MadsKristensen.EditorExtensions
 
         public void StartSearch(INavigateToCallback callback, string searchValue)
         {
+            Debug.Assert(_currentWorker == null);
+
             if (searchValue.Length > 0 && (searchValue[0] == '.' || searchValue[0] == '#'))
             {
-                CssParser parser = new CssParser();
-                var state = new Tuple<CssParser, string, INavigateToCallback>(parser, searchValue, callback);
-
-                System.Threading.ThreadPool.QueueUserWorkItem(DoWork, state);
+                _currentWorker = new Worker(_owner, callback, searchValue);
             }
-        }
-
-        public void DoWork(object state)
-        {
-            var tuple = (Tuple<CssParser, string, INavigateToCallback>)state;
-            var parser = tuple.Item1;
-            var searchValue = tuple.Item2;
-            var callback = tuple.Item3;
-
-            try
-            {
-                IList<string> files = GetFiles().ToList();
-
-                Parallel.For(0, files.Count, i =>
-                {
-                    string file = files[i];
-
-                    IEnumerable<ParseItem> items = GetItems(file, parser, searchValue);
-
-                    foreach (ParseItem sel in items)
-                    {
-                        callback.AddItem(new NavigateToItem(searchValue, NavigateToItemKind.Field, "CSS", searchValue, new CssGoToLineTag(sel, file), MatchKind.Exact, _owner));
-                    }
-
-                    callback.ReportProgress(i, files.Count);
-                });
-            }
-            catch { }
-            finally
+            else
             {
                 callback.Done();
             }
@@ -63,42 +156,10 @@ namespace MadsKristensen.EditorExtensions
 
         public void StopSearch()
         {
-        }
-
-        private static IEnumerable<ParseItem> GetItems(string file, CssParser parser, string searchValue)
-        {
-            StyleSheet ss = parser.Parse(File.ReadAllText(file), true);
-
-            return new CssItemAggregator<ParseItem>
+            var currentWorker = Interlocked.Exchange(ref _currentWorker, null);
+            if (currentWorker != null)
             {
-                (ClassSelector c) => c.Text.Contains(searchValue) ? c : null,
-                (IdSelector c) => c.Text.Contains(searchValue) ? c : null
-            }.Crawl(ss).Where(s => s != null);
-        }
-
-        private static IEnumerable<string> GetFiles()
-        {
-            string folder = ProjectHelpers.GetRootFolder();
-
-            if (string.IsNullOrEmpty(folder))
-            {
-                var doc = EditorExtensionsPackage.DTE.ActiveDocument;
-                if (doc != null)
-                    folder = ProjectHelpers.GetProjectFolder(EditorExtensionsPackage.DTE.ActiveDocument.FullName);
-            }
-
-            if (string.IsNullOrEmpty(folder))
-                yield break;
-
-            List<string> files = new List<string>();
-
-            files.AddRange(Directory.GetFiles(folder, "*.less", SearchOption.AllDirectories));
-            files.AddRange(Directory.GetFiles(folder, "*.css", SearchOption.AllDirectories));
-
-            foreach (string file in files)
-            {
-                if (!file.Contains(".min.") && !file.Contains(".bundle."))
-                    yield return file;
+                currentWorker.Cancel();
             }
         }
     }


### PR DESCRIPTION
The previous implementation of CSS INavigateTo wasn't cancellable.  This
meant user searches with non-trivial names were doing a lot of
unnecessary work.  Pretty much every character typed into the search box
results in a call to StopSearch followed by StartSearch with the new
search value.  The previous implementation wasn't cancelling searches in
StopSearch and hence a lot of unnecessary work was being done on
projects with big individual files or simply a large number of CSS
files.  This change makes the search fully cancellable and removes the
unnecessary work.

It also fixes one small bug.  In the case where we didn't want to search
at all (the search string didn't start with # or .) then we still need
to call INavigateToCallback.Done.
