### PR TITLE
LESS: Used basepath for more robust solution

### DIFF
--- a/EditorExtensions/Margin/LessCompiler.cs
+++ b/EditorExtensions/Margin/LessCompiler.cs
@@ -23,10 +23,11 @@ namespace MadsKristensen.EditorExtensions
         {
             string output = Path.GetTempFileName();
             string arguments = String.Format("--no-color --relative-urls \"{0}\" \"{1}\"", fileName, output);
+            string baseFolder = ProjectHelpers.GetRootFolder() ?? Path.GetDirectoryName(targetFileName);
 
             if (WESettings.GetBoolean(WESettings.Keys.LessSourceMaps))
-                arguments = String.Format("--no-color --relative-urls --source-map=\"{0}.map\" \"{1}\" \"{2}\"",
-                    targetFileName, fileName, output);
+                arguments = String.Format("--no-color --relative-urls --source-map-basepath=\"{0}\" --source-map=\"{1}.map\" \"{2}\" \"{3}\"",
+                    baseFolder.Replace("\\","/"), targetFileName, fileName, output);
 
             ProcessStartInfo start = new ProcessStartInfo(String.Format("\"{0}\" \"{1}\"", (File.Exists(node)) ? node : "node", lessCompiler))
             {

--- a/EditorExtensions/Margin/LessMargin.cs
+++ b/EditorExtensions/Margin/LessMargin.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Web.Helpers;
@@ -126,22 +127,11 @@ namespace MadsKristensen.EditorExtensions
             if (jsonSourceMap == null)
                 return null;
 
-            jsonSourceMap.sources = UpdateSourcePaths(new List<dynamic>(jsonSourceMap.sources), cssFileName, lessFileName);
+            jsonSourceMap.sources = ((IEnumerable<dynamic>)jsonSourceMap.sources).Select(s => FileHelpers.RelativePath(cssFileName, s));
             jsonSourceMap.names = new List<dynamic>(jsonSourceMap.names);
             jsonSourceMap.file = FileHelpers.RelativePath(lessFileName, cssFileName);
 
             return Json.Encode(jsonSourceMap);
-        }
-
-        private static List<dynamic> UpdateSourcePaths(List<dynamic> sources, string cssFileName, string lessFileName)
-        {
-            for (int i = 0; i < sources.Count; ++i)
-            {
-                sources[i] = FileHelpers.RelativePath(cssFileName,
-                    File.Exists(sources[i]) ? sources[i] : lessFileName);
-            }
-
-            return sources;
         }
 
         private static string UpdateSourceLinkInCssComment(string content, string sourceMapRelativePath)


### PR DESCRIPTION
Notes:
- LESS Compiler: Used `--source-map-basepath` to get the absolute path (for post-processing).
- LESS Post-processing: Removed extra checks and used inline lambda for iteration.
