### PR TITLE
CoffeeScript: Implemented SourceMap feature

### DIFF
--- a/EditorExtensions/Commands/Code/IntellisenseWriter.cs
+++ b/EditorExtensions/Commands/Code/IntellisenseWriter.cs
@@ -203,13 +203,19 @@ namespace MadsKristensen.EditorExtensions
         [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", Justification = "Unambiguous in this context.")]
         public IntellisenseType Type { get; set; }
         public string Summary { get; set; }
-        public IList<IntellisenseAttribute> Attributes { get; set; }
+        public IEnumerable<IntellisenseElement> Attributes { get; set; }
     }
 
-    public class IntellisenseAttribute
+    public class IntellisenseElement
     {
         public string Name { get; set; }
-        public Dictionary<string, string> Values { get; set; }
+        public Dictionary<string, string> Values { get; private set; }
+
+        public IntellisenseElement(string name, Dictionary<string, string> values)
+        {
+            Name = name;
+            Values = values;
+        }
     }
 
     public class IntellisenseType

--- a/EditorExtensions/Commands/Code/ScriptIntellisenseListener.cs
+++ b/EditorExtensions/Commands/Code/ScriptIntellisenseListener.cs
@@ -61,10 +61,10 @@ namespace MadsKristensen.EditorExtensions
             {
                 var item = EditorExtensionsPackage.DTE.Solution.FindProjectItem(filePath);
                 List<IntellisenseObject> list = null;
-                try 
+                try
                 {
                     list = ProcessFile(item);
-                } 
+                }
                 catch (Exception ex)
                 {
                     Logger.Log("An error occurred while processing code in " + filePath + "\n" + ex
@@ -229,7 +229,8 @@ namespace MadsKristensen.EditorExtensions
             var cl = codeTypeRef.CodeType as CodeClass;
             var en = codeTypeRef.CodeType as CodeEnum;
             var isPrimitive = IsPrimitive(codeTypeRef);
-            var result = new IntellisenseType {
+            var result = new IntellisenseType
+            {
                 IsArray = isArray || isCollection,
                 CodeName = codeTypeRef.AsString,
                 ClientSideReferenceName =
@@ -319,14 +320,14 @@ namespace MadsKristensen.EditorExtensions
             }
         }
 
-        private static IList<IntellisenseAttribute> GetAttributes(CodeElements elements)
+        private static IList<IntellisenseElement> GetAttributes(CodeElements elements)
         {
             return elements.Cast<CodeElement>()
-                           .Select(a => new IntellisenseAttribute
-                           {
-                               Name = a.Name,
-                               Values = a.Children.OfType<CodeAttributeArgument>().ToDictionary(b => b.Name, b => b.Value.Substring(1, b.Value.Length - 2)) // Strip the leading & trailing quotes
-                           }).ToList();
+                           .Select(a => new IntellisenseElement
+                           (
+                               name: a.Name,
+                               values: a.Children.OfType<CodeAttributeArgument>().ToDictionary(b => b.Name, b => b.Value.Substring(1, b.Value.Length - 2)) // Strip the leading & trailing quotes
+                           )).ToList();
         }
     }
 }

--- a/EditorExtensions/Margin/CoffeeScriptCompiler.cs
+++ b/EditorExtensions/Margin/CoffeeScriptCompiler.cs
@@ -25,6 +25,13 @@ namespace MadsKristensen.EditorExtensions
         protected override void SetArguments(string sourceFileName, string targetFileName)
         {
             Arguments = WESettings.GetBoolean(WESettings.Keys.WrapCoffeeScriptClosure) ? "--bare " : "";
+
+            if (WESettings.GetBoolean(WESettings.Keys.CoffeeScriptSourceMaps))
+            {
+                Arguments += String.Format(CultureInfo.CurrentCulture, "--runtime inline --output \"{0}\" --map --compile \"{1}\"", Path.GetDirectoryName(targetFileName), sourceFileName);
+                return;
+            }
+
             Arguments += String.Format(CultureInfo.CurrentCulture, "--runtime inline --output \"{0}\" --compile \"{1}\"", Path.GetDirectoryName(targetFileName), sourceFileName);
         }
 

--- a/EditorExtensions/Margin/LessMargin.cs
+++ b/EditorExtensions/Margin/LessMargin.cs
@@ -103,7 +103,7 @@ namespace MadsKristensen.EditorExtensions
 
             WriteFile(updatedFileContent, sourceMapFilename, true, false);
 
-            return UpdateSourceLinkInCssComment(content, FileHelpers.RelativePath(sourceMapFilename, sourceFileName));
+            return UpdateSourceLinkInCssComment(content, FileHelpers.RelativePath(sourceMapFilename, compiledFileName));
         }
 
         private static string GetUpdatedSourceMapFileContent(string cssFileName, string sourceMapFilename)

--- a/EditorExtensions/Margin/NodeExecutorBase.cs
+++ b/EditorExtensions/Margin/NodeExecutorBase.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -9,9 +8,8 @@ namespace MadsKristensen.EditorExtensions
 {
     public abstract class NodeExecutorBase
     {
-        private string ErrorFileName;
         protected static readonly string WebEssentialsNodeDirectory = Path.Combine(Path.GetDirectoryName(typeof(LessCompiler).Assembly.Location), @"Resources\nodejs");
-        protected static readonly string NodePath = (File.Exists(Path.Combine(WebEssentialsNodeDirectory, @"node.exe"))) ? Path.Combine(WebEssentialsNodeDirectory, @"node.exe") : "node";
+        protected static readonly string NodePath = Path.Combine(WebEssentialsNodeDirectory, @"node.exe");
 
         protected string Arguments { get; set; }
         protected abstract string ServiceName { get; }
@@ -22,7 +20,7 @@ namespace MadsKristensen.EditorExtensions
         {
             SetArguments(sourceFileName, targetFileName);
 
-            ErrorFileName = Path.Combine(WebEssentialsNodeDirectory, String.Format(CultureInfo.CurrentCulture, "error-{0}.log", Guid.NewGuid().ToString()));
+            var ErrorFileName = Path.GetTempFileName();
 
             var resultantArguments = string.Format("\"{0}\" \"{1}\"", NodePath, Path.Combine(WebEssentialsNodeDirectory, CompilerPath));
 
@@ -41,7 +39,7 @@ namespace MadsKristensen.EditorExtensions
             {
                 string errorText = "";
 
-                if (File.Exists(ErrorFileName))
+                if (File.Exists(ErrorFileName) && process.ExitCode != 0)
                 {
                     errorText = File.ReadAllText(ErrorFileName);
 

--- a/EditorExtensions/MenuItems/AddIntellisenseFile.cs
+++ b/EditorExtensions/MenuItems/AddIntellisenseFile.cs
@@ -23,12 +23,12 @@ namespace MadsKristensen.EditorExtensions
         public void SetupCommands()
         {
             CommandID JsId = new CommandID(GuidList.guidDiffCmdSet, (int)PkgCmdIDList.cmdJavaScriptIntellisense);
-            OleMenuCommand jsCommand = new OleMenuCommand((s, e) => Execute(".js"), JsId);
+            OleMenuCommand jsCommand = new OleMenuCommand(async (s, e) => await Execute(".js"), JsId);
             jsCommand.BeforeQueryStatus += JavaScript_BeforeQueryStatus;
             _mcs.AddCommand(jsCommand);
 
             CommandID tsId = new CommandID(GuidList.guidDiffCmdSet, (int)PkgCmdIDList.cmdTypeScriptIntellisense);
-            OleMenuCommand tsCommand = new OleMenuCommand((s, e) => Execute(".d.ts"), tsId);
+            OleMenuCommand tsCommand = new OleMenuCommand(async (s, e) => await Execute(".d.ts"), tsId);
             tsCommand.BeforeQueryStatus += TypeScript_BeforeQueryStatus;
             _mcs.AddCommand(tsCommand);
         }

--- a/EditorExtensions/Options/CoffeeScript.cs
+++ b/EditorExtensions/Options/CoffeeScript.cs
@@ -17,6 +17,7 @@ namespace MadsKristensen.EditorExtensions
             Settings.SetValue(WESettings.Keys.WrapCoffeeScriptClosure, WrapCoffeeScriptClosure);
             Settings.SetValue(WESettings.Keys.CoffeeScriptMinify, CoffeeScriptMinify);
             Settings.SetValue(WESettings.Keys.CoffeeScriptCompileOnBuild, CoffeeScriptCompileOnBuild);
+            Settings.SetValue(WESettings.Keys.CoffeeScriptSourceMaps, CoffeeScriptSourceMaps);
             Settings.SetValue(WESettings.Keys.CoffeeScriptEnableCompiler, CoffeeScriptEnableCompiler);
             Settings.SetValue(WESettings.Keys.CoffeeScriptCompileToLocation, CoffeeScriptCompileToLocation ?? string.Empty);
 
@@ -30,6 +31,7 @@ namespace MadsKristensen.EditorExtensions
             WrapCoffeeScriptClosure = WESettings.GetBoolean(WESettings.Keys.WrapCoffeeScriptClosure);
             CoffeeScriptMinify = WESettings.GetBoolean(WESettings.Keys.CoffeeScriptMinify);
             CoffeeScriptCompileOnBuild = WESettings.GetBoolean(WESettings.Keys.CoffeeScriptCompileOnBuild);
+            CoffeeScriptSourceMaps = WESettings.GetBoolean(WESettings.Keys.CoffeeScriptSourceMaps);
             CoffeeScriptEnableCompiler = WESettings.GetBoolean(WESettings.Keys.CoffeeScriptEnableCompiler);
             CoffeeScriptCompileToLocation = WESettings.GetString(WESettings.Keys.CoffeeScriptCompileToLocation);
         }
@@ -57,6 +59,11 @@ namespace MadsKristensen.EditorExtensions
         [Category("CoffeeScript")]
         [DefaultValue(true)]
         public bool CoffeeScriptMinify { get; set; }
+
+        [LocDisplayName("Generate source maps")]
+        [Description("Creates a source map when compiling the JavaScript file (file.js.map).")]
+        [Category("CoffeeScript")]
+        public bool CoffeeScriptSourceMaps { get; set; }
 
         [LocDisplayName("Compile on build")]
         [Description("Compiles all CoffeeScript files in the project that has a corresponding .js file.")]

--- a/EditorExtensions/Options/ProjectSettingsStore.cs
+++ b/EditorExtensions/Options/ProjectSettingsStore.cs
@@ -251,7 +251,7 @@ namespace MadsKristensen.EditorExtensions
             dic.Add(Keys.GenerateJsFileFromCoffeeScript, true);
             dic.Add(Keys.ShowCoffeeScriptPreviewWindow, true);
             dic.Add(Keys.CoffeeScriptEnableCompiler, true);
-            dic.Add(Keys.CoffeeScriptCompileToLocation, true);
+            dic.Add(Keys.CoffeeScriptCompileToLocation, string.Empty);
 
             // Markdown
             dic.Add(Keys.MarkdownShowPreviewWindow, true);

--- a/EditorExtensions/Options/WebEssentialsSettings.cs
+++ b/EditorExtensions/Options/WebEssentialsSettings.cs
@@ -32,6 +32,7 @@ namespace MadsKristensen.EditorExtensions
             public const string CoffeeScriptMinify = "CoffeeScriptMinify";
             public const string WrapCoffeeScriptClosure = "CoffeeScriptWrapClosure";
             public const string CoffeeScriptCompileOnBuild = "CoffeeScriptCompileOnBuild";
+            public const string CoffeeScriptSourceMaps = "CoffeeScriptSourceMaps";
             public const string CoffeeScriptEnableCompiler = "CoffeeScriptEnableCompiler";
             public const string CoffeeScriptCompileToLocation = "CoffeeScriptCompileToLocation";
 


### PR DESCRIPTION
**Note:**

The SourceMap feature is functional, except when he "Custom Compile To" path is set. Contrary to LESS (which provides bunch of switches to customize source-maps paths), CoffeeScript compiler exposes `--map` CLI optional switch, which automatically generate paths based on the location of source and compiled files. Currently, their implementation is broken.

For that matter, I have opened an issue in `CoffeeScript` repo: https://github.com/jashkenas/coffee-script/issues/3296. There is nothing much we can do here, unless coffee compiler generates absolute or relative paths in `sources[]` (inside `.map` file).
