### PR TITLE
BrowserLink: Fix #404

### DIFF
--- a/EditorExtensions/BrowserLink/Menu/MenuBrowserLink.js
+++ b/EditorExtensions/BrowserLink/Menu/MenuBrowserLink.js
@@ -81,7 +81,7 @@
         label.innerHTML = text;
         label.title = tooltip;
         label.style.fontWeight = "normal";
-        label.for = id;
+        label.htmlFor = id;
 
         item.checked = function (value) {
             if (typeof (value) === typeof (undefined)) {


### PR DESCRIPTION
for is a keyword and cannot be used
as a property name.
The correct property is htmlFor.

I don't know why this ever worked; apparently, some browsers & parsers are too forgiving.

http://msdn.microsoft.com/en-us/library/vstudio/ms533872
