### PR TITLE
TypeSript: Improve .d.ts for enums

### DIFF
--- a/EditorExtensions/Commands/Code/IntellisenseParser.cs
+++ b/EditorExtensions/Commands/Code/IntellisenseParser.cs
@@ -164,11 +164,13 @@ namespace MadsKristensen.EditorExtensions
                 Summary = GetSummary(element),
             };
 
-            foreach (var codeEnum in element.Members.OfType<CodeElement>())
+            foreach (var codeEnum in element.Members.OfType<CodeVariable>())
             {
                 var prop = new IntellisenseProperty
                 {
                     Name = codeEnum.Name,
+                    Summary = GetSummary(codeEnum),
+                    InitExpression = codeEnum.InitExpression
                 };
 
                 data.Properties.Add(prop);
@@ -354,26 +356,28 @@ namespace MadsKristensen.EditorExtensions
         }
 
         // External items throw an exception from the DocComment getter
-        private static string GetSummary(CodeProperty property) { return property.InfoLocation != vsCMInfoLocation.vsCMInfoLocationProject ? null : GetSummary(property.InfoLocation, property.DocComment, property.FullName); }
+        private static string GetSummary(CodeProperty property) { return property.InfoLocation != vsCMInfoLocation.vsCMInfoLocationProject ? null : GetSummary(property.InfoLocation, property.DocComment, property.Comment, property.FullName); }
 
-        private static string GetSummary(CodeClass property) { return GetSummary(property.InfoLocation, property.DocComment, property.FullName); }
+        private static string GetSummary(CodeClass property) { return GetSummary(property.InfoLocation, property.DocComment, property.Comment, property.FullName); }
 
-        private static string GetSummary(CodeEnum property) { return GetSummary(property.InfoLocation, property.DocComment, property.FullName); }
+        private static string GetSummary(CodeEnum property) { return GetSummary(property.InfoLocation, property.DocComment, property.Comment, property.FullName); }
 
-        private static string GetSummary(vsCMInfoLocation location, string comment, string fullName)
+        private static string GetSummary(CodeVariable property) { return GetSummary(property.InfoLocation, property.DocComment, property.Comment, property.FullName); }
+
+        private static string GetSummary(vsCMInfoLocation location, string xmlComment, string inlineComment, string fullName)
         {
-            if (location != vsCMInfoLocation.vsCMInfoLocationProject || string.IsNullOrWhiteSpace(comment))
+            if (location != vsCMInfoLocation.vsCMInfoLocationProject || (string.IsNullOrWhiteSpace(xmlComment) && string.IsNullOrWhiteSpace(inlineComment)))
                 return null;
 
             try
             {
-                string summary = XElement.Parse(comment)
+                string summary = XElement.Parse(xmlComment)
                                .Descendants("summary")
                                .Select(x => x.Value)
                                .FirstOrDefault();
-                if (!string.IsNullOrEmpty(summary)) summary = summary.Trim();
-
-                return summary;
+                if (!string.IsNullOrEmpty(summary)) return summary.Trim();
+                if (!string.IsNullOrWhiteSpace(inlineComment)) return inlineComment.Trim();
+                return null;
             }
             catch (Exception ex)
             {

--- a/EditorExtensions/Commands/Code/IntellisenseProperty.cs
+++ b/EditorExtensions/Commands/Code/IntellisenseProperty.cs
@@ -21,5 +21,6 @@ namespace MadsKristensen.EditorExtensions
         public IntellisenseType Type { get; set; }
 
         public string Summary { get; set; }
+        public object InitExpression { get; set; }
     }
 }


### PR DESCRIPTION
Adding C# enumerators initializer in the generated .d.ts
If the DocComment is null or empty try to fallback on the  inlineComment

Now when you create the .d.ts of an enum it will have the comments and the default value
