### PR TITLE
SASS: Added SourceMap support

### DIFF
--- a/EditorExtensions/Commands/Css/CssAddMissingStandardCommandTarget.cs
+++ b/EditorExtensions/Commands/Css/CssAddMissingStandardCommandTarget.cs
@@ -45,7 +45,7 @@ namespace MadsKristensen.EditorExtensions
 
                 EditorExtensionsPackage.ExecuteCommand("Edit.FormatDocument");
                 TextView.ViewScroller.ScrollViewportVerticallyByLines(ScrollDirection.Down, TextView.TextSnapshot.GetLineNumberFromPosition(scrollPosition));
-                EditorExtensionsPackage.DTE.StatusBar.Text = count +  " missing standard properties added";
+                EditorExtensionsPackage.DTE.StatusBar.Text = count + " missing standard properties added";
             }
 
             return true;

--- a/EditorExtensions/Compilers/LESS/LessCompiler.cs
+++ b/EditorExtensions/Compilers/LESS/LessCompiler.cs
@@ -14,7 +14,6 @@ namespace MadsKristensen.EditorExtensions
     public class LessCompiler : NodeExecutorBase
     {
         private static readonly string _compilerPath = Path.Combine(WebEssentialsResourceDirectory, @"nodejs\tools\node_modules\less\bin\lessc");
-        private static readonly Regex _linesStartingWithTwoSpaces = new Regex("(\n( *))", RegexOptions.Compiled);
         private static readonly Regex _errorParsingPattern = new Regex(@"^(?<message>.+) in (?<fileName>.+) on line (?<line>\d+), column (?<column>\d+):$", RegexOptions.Multiline);
         private static readonly Regex _sourceMapInCss = new Regex(@"\/\*#([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*\/", RegexOptions.Multiline);
 

--- a/EditorExtensions/Compilers/NodeExecutorBase.cs
+++ b/EditorExtensions/Compilers/NodeExecutorBase.cs
@@ -45,13 +45,12 @@ namespace MadsKristensen.EditorExtensions
             {
                 using (var process = await start.ExecuteAsync())
                 {
-                    string errorText = "";
-
-                    // Subjected to change, depending on https://github.com/andrew/node-sass/issues/207
-                    if (File.Exists(errorOutputFile))
-                        errorText = File.ReadAllText(errorOutputFile).Trim();
-
-                    return ProcessResult(process, errorText, sourceFileName, targetFileName);
+                    return ProcessResult(
+                                            process,
+                                            File.ReadAllText(errorOutputFile).Trim(),
+                                            sourceFileName,
+                                            targetFileName
+                                        );
                 }
             }
             finally
@@ -83,8 +82,8 @@ namespace MadsKristensen.EditorExtensions
         private void ValidateResult(Process process, string outputFile, string errorText, CompilerResult result)
         {
             try
-            {   // Subjected to change, depending on https://github.com/andrew/node-sass/issues/207
-                if (!errorText.Contains("error: ") && process.ExitCode == 0)
+            {
+                if (process.ExitCode == 0)
                 {
                     if (!string.IsNullOrEmpty(outputFile))
                         result.Result = File.ReadAllText(outputFile);

--- a/EditorExtensions/Compilers/SASS/SassCompiler.cs
+++ b/EditorExtensions/Compilers/SASS/SassCompiler.cs
@@ -31,14 +31,14 @@ namespace MadsKristensen.EditorExtensions
         }
         protected override string GetArguments(string sourceFileName, string targetFileName)
         {
-            var args = new StringBuilder("--output-style=expanded ");
+            var args = new StringBuilder();
 
             if (WESettings.GetBoolean(WESettings.Keys.SassSourceMaps) && !InUnitTests)
             {
-                args.Append("--source-comments=map ");
+                args.Append("--source-map ");
             }
 
-            args.AppendFormat(CultureInfo.CurrentCulture, "\"{0}\" \"{1}\"", sourceFileName, targetFileName);
+            args.AppendFormat(CultureInfo.CurrentCulture, "--output-style=expanded \"{0}\" --output \"{1}\"", sourceFileName, targetFileName);
 
             return args.ToString();
         }
@@ -94,8 +94,11 @@ namespace MadsKristensen.EditorExtensions
 
         private static string GetUpdatedSourceMapFileContent(string cssFileName, string sourceMapFilename)
         {
+            // Should be removed when this is fixed: https://github.com/hcatlin/libsass/issues/242
+            var sourceMapFileContent = File.ReadAllText(sourceMapFilename).Replace("\\", "\\\\");
+
             // Read JSON map file and deserialize.
-            dynamic jsonSourceMap = Json.Decode(File.ReadAllText(sourceMapFilename));
+            dynamic jsonSourceMap = Json.Decode(sourceMapFileContent);
 
             if (jsonSourceMap == null)
                 return null;

--- a/EditorExtensions/MenuItems/Markdown.cs
+++ b/EditorExtensions/MenuItems/Markdown.cs
@@ -44,7 +44,7 @@ namespace MadsKristensen.EditorExtensions
             OleMenuCommand menuCommand = sender as OleMenuCommand;
             var paths = ProjectHelpers.GetSelectedItemPaths(_dte);
 
-            menuCommand.Enabled = paths.Count() > 0 && paths.All(p => _extensions.Contains(Path.GetExtension(p)));
+            menuCommand.Enabled = paths.Any() && paths.All(p => _extensions.Contains(Path.GetExtension(p)));
         }
 
         private void AddHtmlFiles()

--- a/WebEssentialsTests/Tests/LESS/LessCompilationTests.cs
+++ b/WebEssentialsTests/Tests/LESS/LessCompilationTests.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using FluentAssertions;
 using MadsKristensen.EditorExtensions;


### PR DESCRIPTION
Newer version of SASS is just released https://github.com/andrew/node-sass/releases/tag/v0.8.0.

There are still some issues in sourcemaps on their end (https://github.com/hcatlin/libsass/issues/242) which I fixed in our code (post-processing). Once these are resolved, we need to unfix the hack.
