### PR TITLE
Sprite: Removed border & refactored static code

### DIFF
--- a/EditorExtensions/Commands/Shared/PasteImageCommandTarget.cs
+++ b/EditorExtensions/Commands/Shared/PasteImageCommandTarget.cs
@@ -5,7 +5,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
-using System.Windows.Threading;
 using EnvDTE;
 using MadsKristensen.EditorExtensions.Classifications.Markdown;
 using Microsoft.VisualStudio.Text;

--- a/EditorExtensions/MenuItems/SpriteImage.cs
+++ b/EditorExtensions/MenuItems/SpriteImage.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Drawing;
 using System.IO;
@@ -45,7 +44,7 @@ namespace MadsKristensen.EditorExtensions
         private async Task CreateSprite()
         {
             string spriteFile;
-         
+
             if (!GetFileName(out spriteFile))
                 return;
 

--- a/EditorExtensions/Optimization/Sprite/SpriteGenerator.cs
+++ b/EditorExtensions/Optimization/Sprite/SpriteGenerator.cs
@@ -11,7 +11,8 @@ namespace MadsKristensen.EditorExtensions
 {
     public class SpriteGenerator
     {
-        IEnumerable<ImageInfo> rectangles;
+        private IEnumerable<ImageInfo> rectangles;
+        private Sprite sprite;
         public const string MapExtension = ".sprite";
 
         public SpriteGenerator(IEnumerable<ImageInfo> imageInfo)
@@ -25,25 +26,21 @@ namespace MadsKristensen.EditorExtensions
         /// <param name="spriteImageFile">Full path to destination file name</param>
         public void GenerateSpriteWithMaps(string spriteImageFile)
         {
-            Mapper.Canvas canvas = new Mapper.Canvas();
-            MapperOptimalEfficiency<Sprite> mapper = new MapperOptimalEfficiency<Sprite>(canvas);
+            MapperOptimalEfficiency<Sprite> mapper = new MapperOptimalEfficiency<Sprite>(new Canvas());
 
-            Sprite sprite = mapper.Mapping(rectangles);
+            sprite = mapper.Mapping(rectangles);
 
-            GenerateSpriteImage(sprite, spriteImageFile);
+            GenerateSpriteImage(spriteImageFile);
 
-            GenerateSpriteMap(spriteImageFile, sprite.MappedImages);
+            GenerateSpriteMap(spriteImageFile);
         }
 
-        private void GenerateSpriteImage(ISprite sprite, string spriteImageFile)
+        private void GenerateSpriteImage(string spriteImageFile)
         {
             using (Bitmap bitmap = new Bitmap(sprite.Width, sprite.Height, PixelFormat.Format32bppPArgb))
             {
                 using (Graphics graphics = Graphics.FromImage(bitmap))
                 {
-                    // Draw border around the entire image. [Mads] Why?
-                    DrawBorder(graphics, sprite.Width, sprite.Height, 0, 0);
-
                     foreach (IMappedImageInfo map in sprite.MappedImages)
                     {
                         ImageInfo info = map.ImageInfo as ImageInfo;
@@ -58,27 +55,11 @@ namespace MadsKristensen.EditorExtensions
             }
         }
 
-        private static void DrawBorder(Graphics graphics, int width, int height, int xOffset, int yOffset)
-        {
-            // Fill the rectangle
-            Color color = Color.White;
-
-            using (SolidBrush brush = new SolidBrush(color))
-            {
-                graphics.FillRectangle(brush, xOffset, yOffset, width, height);
-            }
-            // Draw border 
-            using (Pen pen = new Pen(Color.Black))
-            {
-                graphics.DrawRectangle(pen, xOffset, yOffset, width - 1, height - 1);
-            }
-        }
-
-        private static void GenerateSpriteMap(string spriteFileName, IEnumerable<IMappedImageInfo> mappedImages)
+        private void GenerateSpriteMap(string spriteFileName)
         {
             var map = new
             {
-                Constituents = mappedImages.Select(mapped =>
+                Constituents = sprite.MappedImages.Select(mapped =>
                 {
                     var info = mapped.ImageInfo as ImageInfo;
                     SpriteMapConstituent image = new SpriteMapConstituent()


### PR DESCRIPTION
@madskristensen, you were right; we don't need border. 

Nonetheless, it looks more _techno_ with darkgreen borders (just a 1px gutter, it will be ignored in any case):

![aa](https://f.cloud.github.com/assets/3840695/1899460/d4b5b302-7c3b-11e3-9ea7-c68e255190f6.png)

(matrix-like) 8-)
