### PR TITLE
Sprite: Optmize quality of sprite

### DIFF
--- a/EditorExtensions/Validation/CSS/Providers/ColorValuesInRangeErrorTagProvider.cs
+++ b/EditorExtensions/Validation/CSS/Providers/ColorValuesInRangeErrorTagProvider.cs
@@ -72,7 +72,7 @@ namespace MadsKristensen.EditorExtensions
                 if (i < 3)
                 {
                     pair = text.Split('%');
-                    
+
                     if (int.TryParse(pair[0], out value))
                     {
                         if (value < 0 || value > 100 && i > 0)


### PR DESCRIPTION
Series of commits for #466:
- Optmize quality of sprite.
- Special optimization for JPEG.

@madskristensen, this will impact the size while keeping the _fair-enough_ quality.
