### PR TITLE
Make JavaScript ignore rule better

### DIFF
--- a/EditorExtensions/Commands/JavaScript/JsHintReporter.cs
+++ b/EditorExtensions/Commands/JavaScript/JsHintReporter.cs
@@ -21,14 +21,19 @@ namespace MadsKristensen.EditorExtensions
             return base.RunLinterAsync();
         }
 
-        public static bool ShouldIgnore(string file)
+        public static bool NotJsOrIsMinifiedOrNotExists(string file)
         {
-            if (!Path.GetExtension(file).Equals(".js", StringComparison.OrdinalIgnoreCase) ||
+            return !Path.GetExtension(file).Equals(".js", StringComparison.OrdinalIgnoreCase) ||
                 file.EndsWith(".min.js", StringComparison.OrdinalIgnoreCase) ||
                 file.EndsWith(".debug.js", StringComparison.OrdinalIgnoreCase) ||
                 file.EndsWith(".intellisense.js", StringComparison.OrdinalIgnoreCase) ||
                 file.Contains("-vsdoc.js") ||
-                !File.Exists(file))
+                !File.Exists(file);
+        }
+
+        public static bool ShouldIgnore(string file)
+        {
+            if (NotJsOrIsMinifiedOrNotExists(file))
             {
                 return true;
             }

--- a/EditorExtensions/Commands/LintFileInvoker.cs
+++ b/EditorExtensions/Commands/LintFileInvoker.cs
@@ -69,6 +69,7 @@ namespace MadsKristensen.EditorExtensions
 
             return Task.WhenAll(
                 Directory.EnumerateFiles(dir, "*" + extension, SearchOption.AllDirectories)
+                            .Where(f => ProjectHelpers.GetProjectItem(f) != null)
                             .Select(f => runnerFactory(f).RunLinterAsync().HandleErrors("linting " + f))
             );
         }

--- a/EditorExtensions/MenuItems/JsCodeStyle.cs
+++ b/EditorExtensions/MenuItems/JsCodeStyle.cs
@@ -45,8 +45,7 @@ namespace MadsKristensen.EditorExtensions
             OleMenuCommand menuCommand = sender as OleMenuCommand;
 
             files = ProjectHelpers.GetSelectedFilePaths()
-                    .Where(f => Path.GetExtension(f).Equals(".ts", System.StringComparison.OrdinalIgnoreCase))
-                    .ToList();
+                    .Where(f => !JsHintReporter.NotJsOrIsMinifiedOrNotExists(f)).ToList();
 
             menuCommand.Enabled = files.Count > 0;
         }

--- a/EditorExtensions/MenuItems/JsHint.cs
+++ b/EditorExtensions/MenuItems/JsHint.cs
@@ -44,7 +44,7 @@ namespace MadsKristensen.EditorExtensions
             OleMenuCommand menuCommand = sender as OleMenuCommand;
 
             var raw = ProjectHelpers.GetSelectedFilePaths();
-            files = raw.Where(f => !JsHintReporter.ShouldIgnore(f)).ToList();
+            files = raw.Where(f => !JsHintReporter.NotJsOrIsMinifiedOrNotExists(f)).ToList();
 
             menuCommand.Enabled = files.Count > 0;
         }

--- a/EditorExtensions/Resources/settings-defaults/.jscs.json
+++ b/EditorExtensions/Resources/settings-defaults/.jscs.json
@@ -9,7 +9,7 @@
     "disallowKeywords": ["with"],
     "disallowMultipleLineBreaks": true,
     "disallowKeywordsOnNewLine": ["else"],
-    "excludeFiles": ["test/data/*.js"],
+    "excludeFiles": ["**/*.min.js", "**/*.debug.js", "**/*.intellisense.js", "**/*-vsdoc.js"],
     "validateJSDoc": {
         "checkParamNames": true,
         "requireParamTypes": true


### PR DESCRIPTION
Includes JSHint, JSCS, default JSCS excludeFiles, with additional
improvement with test project VSHost typing faster.

I know this must be the top priority work for you all. Must be someone working on it. I just try to contribute.

For JsHintReporter.cs, extract NotJsOrIsMinifiedOrNotExists() from ShouldIgonre(), to be use in MenuItems/JsCodeStyle.cs and JsHint.cs. I think minified js should never been JSHint/JSCS. For other default ignored js, they will still be ignore at build. But if user select them explicitly and choose to run JSHint/JSCS, we should not stop it.

For LintFileInvoker.cs, I try to stop it run on non project items. But in my debug test, I don't know why it never hit. Still commit it.

Set .jcsc.json excludeFiles to `["**/*.min.js", "**/*.debug.js", "**/*.intellisense.js", "**/*-vsdoc.js"]`.

For VSHost.cs, original TypeChar will init/cleanup with every single char, I change it into init/cleanup once for a whole string, improve efficiency. And according to http://www.pinvoke.net/default.aspx/Structures/VARIANTARG.html, I change 32 into 16.
This one is not related to others, I don't know whether I should commit/sync/PR this small thing alone, or just put it with other changes like this time.
