### PR TITLE
Less: Fix null ref

### DIFF
--- a/EditorExtensions/Validation/LESS/Filters/LessExtendCssErrorFilter.cs
+++ b/EditorExtensions/Validation/LESS/Filters/LessExtendCssErrorFilter.cs
@@ -17,7 +17,7 @@ namespace MadsKristensen.EditorExtensions
             {
                 ICssError error = errors[i];
 
-                if (error.Item.StyleSheet is LessStyleSheet && error.Text.Contains(":extend("))
+                if (error.Item.StyleSheet is LessStyleSheet && !string.IsNullOrEmpty(error.Text) && error.Text.Contains(":extend("))
                 {
                     errors.RemoveAt(i);
                 }


### PR DESCRIPTION
In less, if you have duplicate identifier WE will raise a null ref (because the error.Text is null)

To reproduce just copy/paste this in a less file (while debugging WE)

``` less
body{
    color:red;
}
body{
    color: green;
}
```
