### PR TITLE
TypeScript: Fix utf-8 encoding in generated .d.ts

### DIFF
--- a/EditorExtensions/Commands/Code/IntellisenseWriter.cs
+++ b/EditorExtensions/Commands/Code/IntellisenseWriter.cs
@@ -20,7 +20,7 @@ namespace MadsKristensen.EditorExtensions
             else
                 WriteJavaScript(objects, sb);
 
-            File.WriteAllText(file, sb.ToString());
+            File.WriteAllText(file, sb.ToString(), Encoding.UTF8);
         }
 
         private static string CamelCasePropertyName(string name)


### PR DESCRIPTION
In https://github.com/madskristensen/WebEssentials2013/commit/accfaa1e3444eda4410c253ad9e8842b4bb1614a The `File.WriteAllText(fileName, sb.ToString(), Encoding.UTF8);` has been removed. This is causing issue in languages having accented characters.
