### PR TITLE
Refine build related issues

### DIFF
--- a/EditorExtensions/VSPackage.resx
+++ b/EditorExtensions/VSPackage.resx
@@ -118,10 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="110" xml:space="preserve">
-    <value>Visual Studio 12 Editor Extension</value>
+    <value>Web Essentials 2013</value>
   </data>
   <data name="112" xml:space="preserve">
-    <value>Information about my package</value>
+    <value>Adds many useful features to Visual Studio for web developers.</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="400" type="System.Resources.ResXFileRef, System.Windows.Forms">


### PR DESCRIPTION
I've send two submits, all related to build. Tell me if this two commits in one PR is right or not.

I've change all `CopyToOutputDirectory` from `Always` to `PreserveNewest`. Includes CSS\Snippets\snippets.pkgdef, Resources\Images\preview.png, Resources\Images\WebEssentials2012logo.png, Resources\Images\numbers.png, License.txt. I think `PreserveNewest` should be enough. For original `Always`, even project have no any change, run from VS still need to rebuild, waste lots of time.

The other is fix in PreBuildTask.ExecWithOutputAsync(). Originally it declare var `output` but not using it. I found running node npm will output to stderr, so change the `output` into `error`, and return the right error message from it.

Another problem wish to address, but not sure if it is ok. In my machine, build takes more than 1 to 1.5 minute. I found the most time consuming part is in the `BeforeBuild` dynamic include content from node modules. By remarking all of them, with statically include all files under Resources\nodejs , build time can reduce to 6 seconds.
Can we just include all those files in project just like all other files? We only need to change these files while there are new release about them. Although update when new release takes some time, but the build time waste with everyone's every build is even more. And I wonder that by current `PreBuildTask`, it only download/install node/npm/modules when they are not existed. How do you update your local ones when they have new releases? Delete the whole folder whenever you want? I don't know whether this may break node/npm or not? Can statically include these files helps when any of them update? Just any of us update, PR then get merged, then all of us get the new release.
