### PR TITLE
Compiler: Fixed njsproj compilation issue

### DIFF
--- a/EditorExtensions/CSS/Commands/CssCreationListener.cs
+++ b/EditorExtensions/CSS/Commands/CssCreationListener.cs
@@ -2,7 +2,6 @@
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;

--- a/EditorExtensions/Shared/Compilers/CompilerRunner.cs
+++ b/EditorExtensions/Shared/Compilers/CompilerRunner.cs
@@ -75,14 +75,17 @@ namespace MadsKristensen.EditorExtensions.Compilers
 
             ProjectItem item = ProjectHelpers.GetProjectItem(sourcePath);
 
-            if (item != null)
-            {
-                // Ignore files nested under other files such as bundle or TypeScript output
-                ProjectItem parent = item.Collection.Parent as ProjectItem;
 
-                if (parent != null && parent.Kind == EnvDTE.Constants.vsProjectItemKindPhysicalFile)
-                    return false;
-            }
+            if (item != null)
+                try
+                {
+                    // Ignore files nested under other files such as bundle or TypeScript output
+                    ProjectItem parent = item.Collection.Parent as ProjectItem;
+
+                    if (parent != null && parent.Kind == EnvDTE.Constants.vsProjectItemKindPhysicalFile)
+                        return false;
+                }
+                catch (InvalidOperationException) { }
 
             var parentExtension = Path.GetExtension(Path.GetFileNameWithoutExtension(sourcePath));
             return !_disallowedParentExtensions.Contains(parentExtension);

--- a/EditorExtensions/Shared/Helpers/ProjectHelpers.cs
+++ b/EditorExtensions/Shared/Helpers/ProjectHelpers.cs
@@ -450,11 +450,9 @@ namespace MadsKristensen.EditorExtensions
 
             var dependentItem = ProjectHelpers.GetProjectItem(fileName);
 
-            if (item.ContainingProject.GetType().Name == "OAProject" && item.ProjectItems != null)
+            if (dependentItem != null && item.ContainingProject.GetType().Name == "OAProject" && item.ProjectItems != null)
             {
                 // WinJS
-                if (dependentItem == null)
-                    return null;
 
                 // check if the file already added ( adding second time fails with ADDRESULT_Cancel )
                 if (dependentItem.Kind != Guid.Empty.ToString("B"))


### PR DESCRIPTION
Fixed the bug which was preventing less and scss compilation from `CompilerRunner`.

Furthermore, I have tried all the methods which I can find to add the compiled files to the project, but `AddFromFile()` always return null when `item.ContainingProject.Object.GetType().Name == "NodejsProjectNode"` (in ProjectHelpers.AddFileToProject).
