### PR TITLE
SourceMap: Decodings factory added

### DIFF
--- a/EditorExtensions/Shared/ExtensionMethods/Extensions.cs
+++ b/EditorExtensions/Shared/ExtensionMethods/Extensions.cs
@@ -92,6 +92,25 @@ namespace MadsKristensen.EditorExtensions
         {
             return input.All(digit => char.IsDigit(digit) || digit.Equals('.'));
         }
+        //<summary>Find the nth occurance of needle in haystack.</summary>.
+        public static int NthIndexOfCharInString(this string strHaystack, char charNeedle, int intOccurrenceToFind)
+        {
+            if (intOccurrenceToFind < 1) return 0;
+
+            int intReturn = -1;
+            int count = 0;
+            int n = 0;
+
+            while (count < intOccurrenceToFind && (n = strHaystack.IndexOf(charNeedle, n)) != -1)
+            {
+                n++;
+                count++;
+            }
+
+            if (count == intOccurrenceToFind) intReturn = n;
+
+            return intReturn;
+        }
 
         ///<summary>Execute process asynchronously.</summary>
         public static Task<Process> ExecuteAsync(this ProcessStartInfo startInfo)

--- a/EditorExtensions/Shared/Helpers/CssSourceMap.cs
+++ b/EditorExtensions/Shared/Helpers/CssSourceMap.cs
@@ -1,0 +1,145 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Web.Helpers;
+using Microsoft.CSS.Core;
+using Microsoft.CSS.Editor;
+using Microsoft.VisualStudio.Utilities;
+
+namespace MadsKristensen.EditorExtensions
+{
+    ///<summary>Shared class between Base64Vlq and CssSourceMap</summary>
+    public class CssSourceMapNode : SourceMapNode
+    {
+        public RuleSet GeneratedItem { get; set; }
+        public RuleSet OriginalItem { get; set; }
+    }
+
+    ///<summary>CSS source map factory.</summary>
+    ///<remarks>
+    /// The objects of this class will be instantiated
+    /// when LESS or SCSS document is loaded in VS,
+    /// and finally get stored in DependencyGraph.
+    ///</remarks>
+    public class CssSourceMap
+    {
+        private string _directory;
+        private ICssParser _parser;
+
+        public IEnumerable<CssSourceMapNode> MapNodes { get; private set; }
+        public bool IsDirty { get; private set; }
+
+        public CssSourceMap(string sourceFileName, string targetFileName, string mapFileName, IContentType contentType)
+        {
+            _parser = CssParserLocator.FindComponent(contentType).CreateParser();
+            _directory = Path.GetDirectoryName(sourceFileName);
+            IsDirty = PopulateMap(targetFileName, mapFileName); // Begin two-steps initialization.
+        }
+
+        private bool PopulateMap(string targetFileName, string mapFileName)
+        {
+            V3SourceMap map = new V3SourceMap();
+
+            try
+            {
+                map = Json.Decode<V3SourceMap>(File.ReadAllText(mapFileName));
+            }
+            catch
+            {
+                return false;
+            }
+
+            MapNodes = Base64Vlq.Decode(map.mappings, _directory, map.sources);
+
+            if (MapNodes.Count() == 0)
+                return false;
+
+            return CollectRules(targetFileName);
+        }
+
+        private bool CollectRules(string targetFileName)
+        {
+            // Sort collection for generated file.
+            MapNodes = MapNodes.OrderBy(x => x.GeneratedLine)
+                               .ThenBy(x => x.GeneratedColumn);
+
+            MapNodes = ProcessCollection(File.ReadAllText(targetFileName));
+
+            // Sort collection for source file.
+            MapNodes = MapNodes.OrderBy(x => x.SourceFilePath)
+                               .ThenBy(x => x.OriginalLine)
+                               .ThenBy(x => x.OriginalColumn);
+
+            MapNodes = ProcessCollection();
+
+            return MapNodes.Any();
+        }
+
+        private IEnumerable<CssSourceMapNode> ProcessCollection(string fileContents = null)
+        {
+            RuleSet rule = null;
+            ParseItem item = null;
+            StyleSheet styleSheet = null;
+
+            var result = new List<CssSourceMapNode>();
+            var contentCollection = new Dictionary<string, string>(); // So we don't have to read file for each map item.
+
+            int start = 0, column, line;
+            bool isSource = true;
+
+            if (fileContents != null) // Means its generated CSS file
+            {
+                styleSheet = new CssParser().Parse(fileContents, false);
+                isSource = false;
+            }
+
+            foreach (var node in MapNodes)
+            {
+                if (!isSource)
+                {
+                    column = node.GeneratedColumn;
+                    line = node.GeneratedLine;
+                }
+                else
+                {
+                    column = node.OriginalColumn;
+                    line = node.OriginalLine;
+
+                    // Cache file contents for LESS/SCSS.
+                    if (!contentCollection.ContainsKey(node.SourceFilePath))
+                    {
+                        fileContents = File.ReadAllText(node.SourceFilePath);
+
+                        contentCollection.Add(node.SourceFilePath, fileContents);
+
+                        styleSheet = _parser.Parse(fileContents, false);
+                    }
+                }
+
+                start = fileContents.NthIndexOfCharInString('\n', line - 1);
+                start += column;
+
+                item = styleSheet.ItemAfterPosition(start);
+                rule = item.FindType<RuleSet>();
+
+                if (rule == null)
+                    continue;
+
+                if (isSource)
+                    node.OriginalItem = rule;
+                else
+                    node.GeneratedItem = rule;
+
+                result.Add(node);
+            }
+
+            return result;
+        }
+
+        private struct V3SourceMap
+        {
+            public string mappings;
+            public string[] sources;
+        }
+    }
+}

--- a/EditorExtensions/Shared/Helpers/SourceMapNode.cs
+++ b/EditorExtensions/Shared/Helpers/SourceMapNode.cs
@@ -1,0 +1,12 @@
+
+namespace MadsKristensen.EditorExtensions
+{
+    public abstract class SourceMapNode
+    {
+        public string SourceFilePath { get; set; }
+        public int GeneratedColumn { get; set; }
+        public int GeneratedLine { get; set; }
+        public int OriginalColumn { get; set; }
+        public int OriginalLine { get; set; }
+    }
+}

--- a/EditorExtensions/WebEssentials2013.csproj
+++ b/EditorExtensions/WebEssentials2013.csproj
@@ -307,6 +307,8 @@
     <Compile Include="Markdown\Classify\MarkdownParser.cs" />
     <Compile Include="SCSS\SmartTags\ScssExtractVariableSmartTagProvider.cs" />
     <Compile Include="Shared\Completion\ColorSwatchIntellisenseProvider.cs" />
+    <Compile Include="Shared\Helpers\SourceMapNode.cs" />
+    <Compile Include="Shared\Helpers\CssSourceMap.cs" />
     <Compile Include="Shared\Helpers\Base64Vlq.cs" />
     <Compile Include="SweetJs\ContentType\SweetJsContentTypeDefinition.cs" />
     <Compile Include="RobotsTxt\Classify\RobotsTxtClassificationTypes.cs" />

--- a/WebEssentialsTests/Tests/Shared/Base64VLQ.cs
+++ b/WebEssentialsTests/Tests/Shared/Base64VLQ.cs
@@ -12,7 +12,7 @@ namespace WebEssentialsTests.Tests.Shared
         {
             var testString = @"AASA;EACI,aAAa,2BAAb;EACA,SAAS,kEAAT";
             var expected = new[] { 1, 2, 2, 2, 3, 3, 3 };
-            var collection = Vlq.Decode(testString).ToArray();
+            var collection = Vlq.Decode(testString, "./").ToArray();
 
             for (var i = 0; i < collection.Count(); ++i)
             {
@@ -25,7 +25,7 @@ namespace WebEssentialsTests.Tests.Shared
         {
             var testString = @"AAIA,CAAC;EACG,WAAA";
             var expected = new[] { 0, 1, 2, 13 };
-            var collection = Vlq.Decode(testString).ToArray();
+            var collection = Vlq.Decode(testString, "./").ToArray();
 
             for (var i = 0; i < collection.Count(); ++i)
             {
@@ -38,7 +38,7 @@ namespace WebEssentialsTests.Tests.Shared
         {
             var testString = @"AASA;EACI,aAAa,2BAAb;EACA,SAAS,kEAAT";
             var expected = new[] { 10, 11, 11, 11, 12, 12, 12 };
-            var collection = Vlq.Decode(testString).ToArray();
+            var collection = Vlq.Decode(testString, "./").ToArray();
 
             for (var i = 0; i < collection.Count(); ++i)
             {
@@ -51,7 +51,7 @@ namespace WebEssentialsTests.Tests.Shared
         {
             var testString = @"AAIA,CAAC;EACG,WAAA";
             var expected = new[] { 0, 1, 4, 4 };
-            var collection = Vlq.Decode(testString).ToArray();
+            var collection = Vlq.Decode(testString, "./").ToArray();
 
             for (var i = 0; i < collection.Count(); ++i)
             {
@@ -70,7 +70,7 @@ namespace WebEssentialsTests.Tests.Shared
                                 new[] { 00, 04, 17, 04, 04, 13, 04 },
                                 new[] { 10, 11, 11, 11, 12, 12, 12 }
                            };
-            var collection = Vlq.Decode(testString).ToArray();
+            var collection = Vlq.Decode(testString, "./").ToArray();
 
             for (var i = 0; i < collection.Count(); ++i)
             {


### PR DESCRIPTION
One step further to accomplish https://github.com/madskristensen/WebEssentials2013/issues/783.

Next steps:
- [ ] Cache the processed `CssSourceMap` instances using `DependencyGraph`, when map file is generated.
- [ ] Wire up selectivity logic with `CssSourceMap`.
- [ ] Add scrolling event handler to preview window for LESS and SCSS using source map (#783). This should preferably be smooth scrolling (if possible).
- [ ] Add context menu to preview window (#783).
