### PR TITLE
Selectivity: Wire-up with CssSourceMap

### DIFF
--- a/EditorExtensions/CSS/DragDrop/StylesheetDrop.cs
+++ b/EditorExtensions/CSS/DragDrop/StylesheetDrop.cs
@@ -7,7 +7,6 @@ using System.Web;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.DragDrop;
 using Microsoft.VisualStudio.Utilities;
-using Microsoft.Web.Editor.EditorHelpers;
 
 namespace MadsKristensen.EditorExtensions.Css
 {

--- a/EditorExtensions/CSS/QuickInfo/Image/ImageQuickInfo.cs
+++ b/EditorExtensions/CSS/QuickInfo/Image/ImageQuickInfo.cs
@@ -12,7 +12,6 @@ using Microsoft.CSS.Editor;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.Web.Editor;
-using Microsoft.Web.Editor.EditorHelpers;
 
 namespace MadsKristensen.EditorExtensions
 {

--- a/EditorExtensions/CSS/SmartTags/Actions/EmbedSmartTagAction.cs
+++ b/EditorExtensions/CSS/SmartTags/Actions/EmbedSmartTagAction.cs
@@ -5,7 +5,6 @@ using System.Windows.Forms;
 using System.Windows.Media.Imaging;
 using Microsoft.CSS.Core;
 using Microsoft.VisualStudio.Text;
-using Microsoft.Web.Editor.EditorHelpers;
 
 namespace MadsKristensen.EditorExtensions.Css
 {

--- a/EditorExtensions/CSS/SmartTags/Actions/OptimizeImageSmartTagAction.cs
+++ b/EditorExtensions/CSS/SmartTags/Actions/OptimizeImageSmartTagAction.cs
@@ -4,7 +4,6 @@ using System.Windows.Media.Imaging;
 using MadsKristensen.EditorExtensions.Images;
 using Microsoft.CSS.Core;
 using Microsoft.VisualStudio.Text;
-using Microsoft.Web.Editor.EditorHelpers;
 
 namespace MadsKristensen.EditorExtensions.Css
 {

--- a/EditorExtensions/CSS/SmartTags/Actions/UpdateEmbedSmartTagAction.cs
+++ b/EditorExtensions/CSS/SmartTags/Actions/UpdateEmbedSmartTagAction.cs
@@ -3,7 +3,6 @@ using System.Globalization;
 using System.IO;
 using System.Windows.Media.Imaging;
 using Microsoft.VisualStudio.Text;
-using Microsoft.Web.Editor.EditorHelpers;
 
 namespace MadsKristensen.EditorExtensions.Css
 {

--- a/EditorExtensions/CSS/Validation/Providers/UnusedCssTagProvider.cs
+++ b/EditorExtensions/CSS/Validation/Providers/UnusedCssTagProvider.cs
@@ -7,7 +7,6 @@ using Microsoft.CSS.Core;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
-using Microsoft.Web.Editor.EditorHelpers;
 
 namespace MadsKristensen.EditorExtensions.Css
 {

--- a/EditorExtensions/HTML/Commands/GoToDefinitionCommandTarget.cs
+++ b/EditorExtensions/HTML/Commands/GoToDefinitionCommandTarget.cs
@@ -11,7 +11,6 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.Web.Editor;
-using Microsoft.Web.Editor.EditorHelpers;
 
 namespace MadsKristensen.EditorExtensions.Html
 {

--- a/EditorExtensions/HTML/Commands/HtmlCreationListener.cs
+++ b/EditorExtensions/HTML/Commands/HtmlCreationListener.cs
@@ -5,7 +5,6 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.Editor;
-using Microsoft.Web.Editor.EditorHelpers;
 using Microsoft.Web.Editor.Formatting;
 
 namespace MadsKristensen.EditorExtensions.Html

--- a/EditorExtensions/HTML/SmartTags/Base64DecodeSmartTag.cs
+++ b/EditorExtensions/HTML/SmartTags/Base64DecodeSmartTag.cs
@@ -8,7 +8,6 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.Editor;
-using Microsoft.Web.Editor.EditorHelpers;
 
 namespace MadsKristensen.EditorExtensions.Html
 {

--- a/EditorExtensions/HTML/SmartTags/RemoteDownloaderSmartTag.cs
+++ b/EditorExtensions/HTML/SmartTags/RemoteDownloaderSmartTag.cs
@@ -11,7 +11,6 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.Editor;
-using Microsoft.Web.Editor.EditorHelpers;
 
 namespace MadsKristensen.EditorExtensions.Html
 {

--- a/EditorExtensions/JavaScript/Commands/NodeModuleGoToDefinition.cs
+++ b/EditorExtensions/JavaScript/Commands/NodeModuleGoToDefinition.cs
@@ -5,7 +5,6 @@ using System.Text.RegularExpressions;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.Web.Editor;
-using Microsoft.Web.Editor.EditorHelpers;
 
 namespace MadsKristensen.EditorExtensions.JavaScript
 {

--- a/EditorExtensions/JavaScript/Commands/ReferenceTagGoToDefinition.cs
+++ b/EditorExtensions/JavaScript/Commands/ReferenceTagGoToDefinition.cs
@@ -5,7 +5,6 @@ using System.Text.RegularExpressions;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.Web.Editor;
-using Microsoft.Web.Editor.EditorHelpers;
 
 namespace MadsKristensen.EditorExtensions.JavaScript
 {

--- a/EditorExtensions/JavaScript/Completion/HTML CompletionSources.cs
+++ b/EditorExtensions/JavaScript/Completion/HTML CompletionSources.cs
@@ -7,7 +7,6 @@ using MadsKristensen.EditorExtensions.Css;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.Web.Editor;
-using Microsoft.Web.Editor.EditorHelpers;
 using Microsoft.Web.Editor.Intellisense;
 using Intel = Microsoft.VisualStudio.Language.Intellisense;
 

--- a/EditorExtensions/JavaScript/Completion/NodeModuleCompletionSourceProvider.cs
+++ b/EditorExtensions/JavaScript/Completion/NodeModuleCompletionSourceProvider.cs
@@ -11,7 +11,6 @@ using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.Editor;
-using Microsoft.Web.Editor.EditorHelpers;
 using Newtonsoft.Json.Linq;
 using Intel = Microsoft.VisualStudio.Language.Intellisense;
 

--- a/EditorExtensions/Markdown/Classify/ContainedLanguageAdapter.cs
+++ b/EditorExtensions/Markdown/Classify/ContainedLanguageAdapter.cs
@@ -22,7 +22,6 @@ using Microsoft.VisualStudio.Web.Editor;
 using Microsoft.VisualStudio.Web.Editor.Workspace;
 using Microsoft.Web.Editor;
 using Microsoft.Web.Editor.ContainedLanguage;
-using Microsoft.Web.Editor.EditorHelpers;
 using VSConstants = Microsoft.VisualStudio.VSConstants;
 
 

--- a/EditorExtensions/Shared/Compilers/CompilerRunner.cs
+++ b/EditorExtensions/Shared/Compilers/CompilerRunner.cs
@@ -134,8 +134,15 @@ namespace MadsKristensen.EditorExtensions.Compilers
             {
                 ProjectHelpers.AddFileToProject(sourcePath, targetPath);
 
-                if (GenerateSourceMap && File.Exists(targetPath + ".map"))
-                    ProjectHelpers.AddFileToProject(targetPath, targetPath + ".map");
+                var mapFile = targetPath + ".map";
+
+                if (GenerateSourceMap && File.Exists(mapFile))
+                {
+                    ProjectHelpers.AddFileToProject(targetPath, mapFile);
+
+                    if (TargetContentType.IsOfType("CSS"))
+                        CssSourceMap.GenerateMaps(mapFile);
+                }
 
                 foreach (var listener in _listeners)
                     listener.FileSaved(TargetContentType, result.TargetFileName, true, Settings.MinifyInPlace);

--- a/EditorExtensions/Shared/ExtensionMethods/Extensions.cs
+++ b/EditorExtensions/Shared/ExtensionMethods/Extensions.cs
@@ -92,6 +92,13 @@ namespace MadsKristensen.EditorExtensions
         {
             return input.All(digit => char.IsDigit(digit) || digit.Equals('.'));
         }
+
+        ///<summary>Find the cloumn position in the last line.</summary>
+        public static int GetLineColumn(this string text, int start, int line)
+        {
+            return start - text.NthIndexOfCharInString('\n', line) - 1;
+        }
+
         //<summary>Find the nth occurance of needle in haystack.</summary>.
         public static int NthIndexOfCharInString(this string strHaystack, char charNeedle, int intOccurrenceToFind)
         {

--- a/EditorExtensions/Shared/ExtensionMethods/IVsExtensions.cs
+++ b/EditorExtensions/Shared/ExtensionMethods/IVsExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
 
 namespace MadsKristensen.EditorExtensions
@@ -97,6 +98,29 @@ namespace MadsKristensen.EditorExtensions
                 c.Description = tooltipGenerator(c);
             }
             return completions;
+        }
+
+        public static string GetFileName(this IPropertyOwner owner)
+        {
+            IVsTextBuffer bufferAdapter;
+
+            owner.Properties.TryGetProperty(typeof(IVsTextBuffer), out bufferAdapter);
+
+            if (bufferAdapter == null)
+                return null;
+
+            var persistFileFormat = bufferAdapter as IPersistFileFormat;
+            string ppzsFilename = null;
+            uint pnFormatIndex;
+            int returnCode = -1;
+
+            if (persistFileFormat != null)
+                returnCode = persistFileFormat.GetCurFile(out ppzsFilename, out pnFormatIndex);
+
+            if (returnCode != VSConstants.S_OK)
+                return null;
+
+            return ppzsFilename;
         }
     }
 }

--- a/EditorExtensions/Shared/Helpers/Base64VLQ.cs
+++ b/EditorExtensions/Shared/Helpers/Base64VLQ.cs
@@ -102,7 +102,7 @@ namespace MadsKristensen.EditorExtensions
 
         public static IEnumerable<CssSourceMapNode> Decode(string vlqValue, string basePath, params string[] sources)
         {
-            int generatedLine = 1, previousSource, previousGeneratedColumn, previousOriginalLine, previousOriginalColumn;
+            int generatedLine = 0, previousSource, previousGeneratedColumn, previousOriginalLine, previousOriginalColumn;
             previousSource = previousGeneratedColumn = previousOriginalLine = previousOriginalColumn = 0;
 
             while (vlqValue.Length > 0)
@@ -147,8 +147,6 @@ namespace MadsKristensen.EditorExtensions
                 temp = VlqDecode(vlqValue);
                 result.OriginalLine = previousOriginalLine + temp.value;
                 previousOriginalLine = result.OriginalLine;
-                // Lines are stored 0-based
-                result.OriginalLine += 1;
                 vlqValue = temp.rest;
 
                 if (vlqValue.Length == 0 || _mappingSeparator.IsMatch(vlqValue.Substring(0, 1)))

--- a/EditorExtensions/Shared/Helpers/CssSourceMap.cs
+++ b/EditorExtensions/Shared/Helpers/CssSourceMap.cs
@@ -1,9 +1,12 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Web.Helpers;
 using Microsoft.CSS.Core;
 using Microsoft.CSS.Editor;
+using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Utilities;
 
 namespace MadsKristensen.EditorExtensions
@@ -11,8 +14,8 @@ namespace MadsKristensen.EditorExtensions
     ///<summary>Shared class between Base64Vlq and CssSourceMap</summary>
     public class CssSourceMapNode : SourceMapNode
     {
-        public RuleSet GeneratedItem { get; set; }
-        public RuleSet OriginalItem { get; set; }
+        public Selector GeneratedSelector { get; set; }
+        public Selector OriginalSelector { get; set; }
     }
 
     ///<summary>CSS source map factory.</summary>
@@ -21,28 +24,169 @@ namespace MadsKristensen.EditorExtensions
     /// when LESS or SCSS document is loaded in VS,
     /// and finally get stored in DependencyGraph.
     ///</remarks>
-    public class CssSourceMap
+    public sealed class CssSourceMap
     {
         private string _directory;
         private ICssParser _parser;
 
+        private static Dictionary<string, IEnumerable<CssSourceMapNode>> _sourceMaps = new Dictionary<string, IEnumerable<CssSourceMapNode>>();
+        private static readonly AsyncReaderWriterLock _rwLock = new AsyncReaderWriterLock();
+
         public IEnumerable<CssSourceMapNode> MapNodes { get; private set; }
         public bool IsDirty { get; private set; }
 
-        public CssSourceMap(string sourceFileName, string targetFileName, string mapFileName, IContentType contentType)
+        private CssSourceMap()
+        { }
+
+        public static dynamic GetSourcePosition(string targetFileName, int line, int column)
+        {
+            var node = GetSourceMapNode(targetFileName, line, column).Result;
+
+            if (node == null)
+                return null;
+
+            return new
+            {
+                file = node.SourceFilePath,
+                line = node.OriginalLine,
+                column = node.OriginalColumn
+            };
+        }
+
+        public static dynamic GetGeneratedPosition(string sourceFileName, string targetFileName, int line, int column)
+        {
+            var node = GetGeneratedMapNode(sourceFileName, targetFileName, line, column, string.IsNullOrEmpty(targetFileName)).Result;
+
+            if (node == null)
+                return null;
+
+            return new
+            {
+                line = node.GeneratedLine,
+                column = node.GeneratedColumn
+            };
+        }
+
+        public static Selector GetSourceSelector(string targetFileName, int line, int column)
+        {
+            var node = GetSourceMapNode(targetFileName, line, column).Result;
+
+            if (node == null)
+                return null;
+
+            return node.OriginalSelector;
+        }
+
+        public static Selector GetGeneratedSelector(string sourceFileName, string targetFileName, int line, int column)
+        {
+            var node = GetGeneratedMapNode(sourceFileName, targetFileName, line, column, string.IsNullOrEmpty(targetFileName)).Result;
+
+            if (node == null)
+                return null;
+
+            return node.GeneratedSelector;
+        }
+
+        private async static Task<CssSourceMapNode> GetSourceMapNode(string targetFileName, int line, int column)
+        {
+            using (await _rwLock.ReadLockAsync())
+            {
+                return _sourceMaps.Where(s => s.Key == targetFileName)
+                                  .SelectMany(s => s.Value)
+                                  .FirstOrDefault(s => s.GeneratedColumn == column && s.GeneratedLine == line);
+            }
+        }
+
+        private async static Task<CssSourceMapNode> GetGeneratedMapNode(string sourceFileName, string targetFileName, int line, int column, bool anyTarget)
+        {
+            if (sourceFileName.EndsWith("scss", StringComparison.OrdinalIgnoreCase))
+                line--;
+
+            using (await _rwLock.ReadLockAsync())
+            {
+                if (!anyTarget && !_sourceMaps.ContainsKey(targetFileName))
+                    return null;
+
+                var map = _sourceMaps.FirstOrDefault(s => (anyTarget || s.Key == targetFileName) && s.Value.Any(k => k.SourceFilePath == sourceFileName)).Value;
+
+                if (map == null)
+                    return null;
+
+                var node = map.FirstOrDefault(n => n.OriginalLine == line && n.OriginalColumn == column);
+
+                if (node != null)
+                    return node;
+
+                // In case of SCSS, white-spaces are not discounted.
+                var nodeSet = map.Where(n => n.OriginalLine == line && n.OriginalColumn < column);
+
+                if (nodeSet.Count() == 0)
+                    return null;
+
+                return nodeSet.OrderBy(o => o.OriginalColumn).Last();
+            }
+        }
+
+        public static void GenerateMaps(string mapFileName)
+        {
+            var json = Json.Decode<SourceMapDefinition>(File.ReadAllText(mapFileName));
+            string extension = Path.GetExtension(json.sources[0]);
+
+            if (!extension.Equals(".less", StringComparison.OrdinalIgnoreCase) &&
+                !extension.Equals(".scss", StringComparison.OrdinalIgnoreCase))
+                return;
+
+            var source = json.sources.Where(s => Path.GetFileNameWithoutExtension(s) == Path.GetFileName(mapFileName.Substring(0, mapFileName.IndexOf(".", StringComparison.Ordinal))));
+
+            if (!source.Any())
+                return;
+
+            var directory = Path.GetDirectoryName(mapFileName);
+            var sourceName = Path.GetFullPath(Path.Combine(directory, source.First()));
+            string targetName = Path.GetFullPath(Path.Combine(directory, json.file));
+
+            if (!File.Exists(sourceName) || !File.Exists(targetName))
+                return;
+
+            var contentType = Mef.GetContentType(extension.TrimStart('.'));
+
+            GenerateMaps(sourceName, targetName, mapFileName, contentType);
+        }
+
+        public static void GenerateMaps(string sourceFileName, string targetFileName, string mapFileName, IContentType contentType)
+        {
+            var map = new CssSourceMap();
+
+            map.Initialize(sourceFileName, targetFileName, mapFileName, contentType);
+
+            if (map.IsDirty)
+                return;
+
+            AddToDictionary(map, sourceFileName, targetFileName);
+        }
+
+        private async static void AddToDictionary(CssSourceMap map, string sourceFileName, string targetFileName)
+        {
+            using (await _rwLock.WriteLockAsync())
+            {
+                _sourceMaps[targetFileName] = map.MapNodes;
+            }
+        }
+
+        private void Initialize(string sourceFileName, string targetFileName, string mapFileName, IContentType contentType)
         {
             _parser = CssParserLocator.FindComponent(contentType).CreateParser();
             _directory = Path.GetDirectoryName(sourceFileName);
-            IsDirty = PopulateMap(targetFileName, mapFileName); // Begin two-steps initialization.
+            IsDirty = !PopulateMap(targetFileName, mapFileName); // Begin two-steps initialization.
         }
 
         private bool PopulateMap(string targetFileName, string mapFileName)
         {
-            V3SourceMap map = new V3SourceMap();
+            var map = new SourceMapDefinition();
 
             try
             {
-                map = Json.Decode<V3SourceMap>(File.ReadAllText(mapFileName));
+                map = Json.Decode<SourceMapDefinition>(File.ReadAllText(mapFileName));
             }
             catch
             {
@@ -77,7 +221,7 @@ namespace MadsKristensen.EditorExtensions
 
         private IEnumerable<CssSourceMapNode> ProcessCollection(string fileContents = null)
         {
-            RuleSet rule = null;
+            Selector selector = null;
             ParseItem item = null;
             StyleSheet styleSheet = null;
 
@@ -105,6 +249,9 @@ namespace MadsKristensen.EditorExtensions
                     column = node.OriginalColumn;
                     line = node.OriginalLine;
 
+                    if (node.SourceFilePath.EndsWith("scss", StringComparison.OrdinalIgnoreCase))
+                        line--; // SCSS line count starts with 1
+
                     // Cache file contents for LESS/SCSS.
                     if (!contentCollection.ContainsKey(node.SourceFilePath))
                     {
@@ -116,19 +263,20 @@ namespace MadsKristensen.EditorExtensions
                     }
                 }
 
-                start = fileContents.NthIndexOfCharInString('\n', line - 1);
+                start = fileContents.NthIndexOfCharInString('\n', line);
                 start += column;
 
                 item = styleSheet.ItemAfterPosition(start);
-                rule = item.FindType<RuleSet>();
 
-                if (rule == null)
+                selector = item.FindType<Selector>();
+
+                if (selector == null)
                     continue;
 
                 if (isSource)
-                    node.OriginalItem = rule;
+                    node.OriginalSelector = selector;
                 else
-                    node.GeneratedItem = rule;
+                    node.GeneratedSelector = selector;
 
                 result.Add(node);
             }
@@ -136,8 +284,9 @@ namespace MadsKristensen.EditorExtensions
             return result;
         }
 
-        private struct V3SourceMap
+        private struct SourceMapDefinition
         {
+            public string file;
             public string mappings;
             public string[] sources;
         }


### PR DESCRIPTION
**Target content-types:** LESS and SCSS.

**Description:** With compile on save, .css and .map
files generation options are enabled, opening
the file and pressing save will generate parsed
source maps. Thereafter, hovering over selector
will calculate selectivity from corresponding
generated selector.

**Remarks:** We may generate the CSS and map files
at temporary location on opening LESS/SCSS
documents regardless of settings; to collect
the compiled version of each Selector. This will
help us adding rich, persistent features.
