### PR TITLE
CSS: Update B64-URI with fallback URL. (#607)

### DIFF
--- a/EditorExtensions/CSS/Classify/EmbeddedImageClassifier.cs
+++ b/EditorExtensions/CSS/Classify/EmbeddedImageClassifier.cs
@@ -1,0 +1,229 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using System.Windows.Threading;
+using MadsKristensen.EditorExtensions.Settings;
+using Microsoft.CSS.Core;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.Utilities;
+
+namespace MadsKristensen.EditorExtensions.Css
+{
+    public static class EmbeddedImageClassificationTypes
+    {
+        public const string Declaration = "image.declaration";
+        public const string Value = "image.value";
+
+        [Export, Name(EmbeddedImageClassificationTypes.Declaration)]
+        public static ClassificationTypeDefinition EmbeddedImageDeclarationClassificationType { get; set; }
+
+        [Export, Name(EmbeddedImageClassificationTypes.Value)]
+        public static ClassificationTypeDefinition EmbeddedImageValueClassificationType { get; set; }
+    }
+
+    [Export(typeof(IClassifierProvider))]
+    [ContentType("css")]
+    public sealed class EmbeddedImageClassifierProvider : IClassifierProvider
+    {
+        [Import]
+        public IClassificationTypeRegistryService Registry { get; set; }
+
+        public IClassifier GetClassifier(ITextBuffer textBuffer)
+        {
+            return textBuffer.Properties.GetOrCreateSingletonProperty<EmbeddedImageClassifier>(() => { return new EmbeddedImageClassifier(Registry, textBuffer); });
+        }
+    }
+
+    internal sealed class EmbeddedImageClassifier : IClassifier
+    {
+        private readonly IClassificationTypeRegistryService _registry;
+        private readonly ITextBuffer _buffer;
+        private readonly CssTreeWatcher _tree;
+        internal readonly SortedRangeList<Declaration> Cache = new SortedRangeList<Declaration>();
+        private readonly IClassificationType _decClassification;
+        private readonly IClassificationType _valClassification;
+
+        internal EmbeddedImageClassifier(IClassificationTypeRegistryService registry, ITextBuffer buffer)
+        {
+            _registry = registry;
+            _buffer = buffer;
+            _decClassification = _registry.GetClassificationType(EmbeddedImageClassificationTypes.Declaration);
+            _valClassification = _registry.GetClassificationType(EmbeddedImageClassificationTypes.Value);
+
+            _tree = CssTreeWatcher.ForBuffer(_buffer);
+            _tree.TreeUpdated += TreeUpdated;
+            _tree.ItemsChanged += TreeItemsChanged;
+            UpdateDeclarationCache(_tree.StyleSheet);
+
+        }
+
+        public IList<ClassificationSpan> GetClassificationSpans(SnapshotSpan span)
+        {
+            List<ClassificationSpan> spans = new List<ClassificationSpan>();
+
+            if (!WESettings.Instance.Css.SyncBase64ImageValues)
+                return spans;
+
+            foreach (Declaration dec in Cache.Where(d => d.PropertyName.Text.EndsWith("background-image", StringComparison.OrdinalIgnoreCase) && span.Start <= d.Start && span.End >= d.AfterEnd))
+            {
+                if (dec.PropertyName.Text.StartsWith("*background", StringComparison.OrdinalIgnoreCase))
+                {
+                    var ss = new SnapshotSpan(span.Snapshot, dec.Start, dec.Length);
+                    var s = new ClassificationSpan(ss, _decClassification);
+                    spans.Add(s);
+                }
+
+                if (dec.Semicolon == null)
+                    continue;
+
+                int start = dec.Colon.AfterEnd;
+                int length = dec.AfterEnd - start;
+                if (span.Snapshot.Length > start + length)
+                {
+                    var ss2 = new SnapshotSpan(span.Snapshot, start, length);
+                    var s2 = new ClassificationSpan(ss2, _valClassification);
+                    spans.Add(s2);
+                }
+            }
+
+            return spans;
+        }
+
+        private void UpdateDeclarationCache(ParseItem item)
+        {
+            var visitor = new CssItemCollector<Declaration>(true);
+            item.Accept(visitor);
+
+            HashSet<RuleBlock> rules = new HashSet<RuleBlock>();
+
+            foreach (Declaration dec in visitor.Items)
+            {
+                RuleBlock rule = dec.Parent as RuleBlock;
+
+                if (rule == null || rules.Contains(rule))
+                    continue;
+
+                var images = rule.Declarations.Where(d => d.PropertyName.Text.Contains("background"));
+
+                foreach (Declaration image in images)
+                {
+                    if (!Cache.Contains(image))
+                        Cache.Add(image);
+                }
+
+                rules.Add(rule);
+            }
+        }
+
+        private void TreeUpdated(object sender, CssTreeUpdateEventArgs e)
+        {
+            Cache.Clear();
+            UpdateDeclarationCache(e.Tree.StyleSheet);
+        }
+
+        private void TreeItemsChanged(object sender, CssItemsChangedEventArgs e)
+        {
+            foreach (ParseItem item in e.DeletedItems)
+            {
+                if (Cache.Contains(item))
+                    Cache.Remove((Declaration)item);
+            }
+
+            foreach (ParseItem item in e.InsertedItems)
+            {
+                UpdateDeclarationCache(item);
+                UpdateEmbeddedImageValues(item);
+            }
+        }
+
+        private void UpdateEmbeddedImageValues(ParseItem item)
+        {
+            if (!WESettings.Instance.Css.SyncBase64ImageValues)
+                return;
+
+            Declaration dec = item.FindType<Declaration>();
+
+            if (dec != null && Cache.Contains(dec))
+            {
+                var url = (UrlItem)dec.Values.First();
+
+                if (!url.IsValid || url.UrlString == null || url.UrlString.Text.Contains(";base64,"))
+                    return;
+
+                var matches = Cache.Where(d => d.IsValid && d != dec && d.Parent == dec.Parent &&
+                                         (d.Values[0].NextSibling as CComment) != null);
+
+                // Undo sometimes messes with the positions, so we have to make this check before proceeding.
+                if (!matches.Any() || dec.Text.Length < dec.Colon.AfterEnd - dec.Start || dec.Colon.AfterEnd < dec.Start)
+                    return;
+
+                string urlText = url.UrlString.Text.Trim('\'', '"');
+                string filePath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(_buffer.GetFileName()), urlText));
+                string b64UrlText = FileHelpers.ConvertToBase64(filePath);
+                string b64Url = url.Text.Replace(urlText, b64UrlText);
+                IEnumerable<Tuple<SnapshotSpan, string>> changes = matches.Reverse().SelectMany(match =>
+                {
+                    ParseItem value = match.Values[0];
+                    CComment comment = value.NextSibling as CComment;
+
+                    SnapshotSpan span = new SnapshotSpan(_buffer.CurrentSnapshot, comment.CommentText.Start, comment.CommentText.Length);
+
+                    url = (UrlItem)value;
+
+                    SnapshotSpan b64Span = new SnapshotSpan(_buffer.CurrentSnapshot, url.Start, url.Length);
+
+                    return new[] { new Tuple<SnapshotSpan, string>(span, urlText), new Tuple<SnapshotSpan, string>(b64Span, b64Url) };
+                });
+
+                Dispatcher.CurrentDispatcher.InvokeAsync(() =>
+                {
+                    using (ITextEdit edit = _buffer.CreateEdit())
+                    {
+                        foreach (Tuple<SnapshotSpan, string> change in changes)
+                        {
+                            SnapshotSpan currentSpan = change.Item1.TranslateTo(_buffer.CurrentSnapshot, SpanTrackingMode.EdgeExclusive);
+                            edit.Replace(currentSpan, change.Item2);
+                        }
+
+                        edit.Apply();
+                    }
+                });
+            }
+        }
+
+        private string GetValueText(Declaration dec)
+        {
+            int start = dec.Colon.AfterEnd;
+            int length = dec.AfterEnd - start;
+            return _buffer.CurrentSnapshot.GetText(start, length);
+        }
+
+        public event EventHandler<ClassificationChangedEventArgs> ClassificationChanged;
+
+        public void RaiseClassificationChanged(SnapshotSpan span)
+        {
+            var handler = this.ClassificationChanged;
+            if (handler != null)
+            {
+                Dispatcher.CurrentDispatcher.BeginInvoke(
+                    new Action(() => handler(this, new ClassificationChangedEventArgs(span))), DispatcherPriority.ApplicationIdle);
+            }
+        }
+    }
+
+    [Export(typeof(EditorFormatDefinition))]
+    [UserVisible(true)]
+    [ClassificationType(ClassificationTypeNames = EmbeddedImageClassificationTypes.Declaration)]
+    [Name(EmbeddedImageClassificationTypes.Declaration)]
+    [Order(After = Priority.Default)]
+    internal sealed class EmbeddedImageDeclarationFormatDefinition : ClassificationFormatDefinition
+    {
+        public EmbeddedImageDeclarationFormatDefinition()
+        {
+            DisplayName = "CSS Embedded Image Property";
+        }
+    }
+}

--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -277,6 +277,12 @@ namespace MadsKristensen.EditorExtensions.Settings
         public bool SyncVendorValues { get; set; }
 
         [Category("IntelliSense")]
+        [DisplayName("Sync embedded image values")]
+        [Description("Synchronize base64 embedded background image property values when modifying the fallback property.")]
+        [DefaultValue(true)]
+        public bool SyncBase64ImageValues { get; set; }
+
+        [Category("IntelliSense")]
         [DisplayName("Show initial/inherit")]
         [Description("Show the global property values 'initial' and 'inherit' in IntelliSense.  Disabling this will not warn if you use them.")]
         [DefaultValue(false)]

--- a/EditorExtensions/Shared/Helpers/FileHelpers.cs
+++ b/EditorExtensions/Shared/Helpers/FileHelpers.cs
@@ -204,6 +204,9 @@ namespace MadsKristensen.EditorExtensions
 
         public static string ConvertToBase64(string fileName)
         {
+            if (!File.Exists(fileName))
+                return string.Empty;
+
             string format = "data:{0};base64,{1}";
             byte[] buffer = File.ReadAllBytes(fileName);
             string extension = Path.GetExtension(fileName).Substring(1);

--- a/EditorExtensions/WebEssentials2013.csproj
+++ b/EditorExtensions/WebEssentials2013.csproj
@@ -284,6 +284,7 @@
     <Compile Include="AppCache\ContentType\AppCacheContentTypeDefinition.cs" />
     <Compile Include="CSS\Classify\ImportantClassifier.cs" />
     <Compile Include="CSS\Classify\VariableClassifier.cs" />
+    <Compile Include="CSS\Classify\EmbeddedImageClassifier.cs" />
     <Compile Include="CSS\Completion\Filter\ColorSwatchCompletionListFilter.cs" />
     <Compile Include="CSS\Completion\Filter\HideUncommonCompletionListFilter.cs" />
     <Compile Include="HTML\Outlining\HtmlRegionTagger.cs" />


### PR DESCRIPTION
New disableable feature added for #607:

**Description:**

When we use the CSS smart tag "Embed as base64 dataUri", to transform the image URL to its B64 counter-part, it generates a fallback declaration for IE6 and 7. For instance:

``` css
background: url('data:text/plain;base64,XXXXXYYYYYZZZZ=') /*../Capture.PNG*/ 0 0;
*background: url('../Capture.PNG') 0 0; /* For IE 6 and 7 */
```

With this feature, changing `Capture.PNG` in above example will automagically update the data-URI and the link in comment.

<del>

---

@spadapet,

It works well, except for the first time it throws an internal exception dialog. Subsequently, after Ok'ing this dialog, it never shows again throughout the session (until new solution is loaded).

The activity log shows 

```xml
    <source>Editor or Editor Extension</source>
    <description>System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.&#x000D;&#x000A;Parameter name: span&#x000D;&#x000A;   at Microsoft.VisualStudio.Text.SnapshotSpan..ctor(ITextSnapshot snapshot, Span span)&#x000D;&#x000A;   at Microsoft.CSS.Editor.CssClassifier.OnTreeItemsChanged(Object sender, CssItemsChangedEventArgs eventArgs)&#x000D;&#x000A;   at System.EventHandler`1.Invoke(Object sender, TEventArgs e)&#x000D;&#x000A;   at Microsoft.CSS.Core.CssTree.FireOnItemsChanged(ParseItemList deletedItems, ParseItemList insertedItems, ParseItemList errorsChangedItems)&#x000D;&#x000A;   at Microsoft.CSS.Core.CssTree.OnTextChange(ITextProvider fullNewText, Int32 changeStart, Int32 deletedLength, Int32 insertedLength)&#x000D;&#x000A;   at Microsoft.CSS.Editor.CssEditorDocument.OnTextBufferChanged(Object sender, TextContentChangedEventArgs eventArgs)&#x000D;&#x000A;   at Microsoft.VisualStudio.Text.Utilities.GuardedOperations.RaiseEvent[TArgs](Object sender, EventHandler`1 eventHandlers, TArgs args)</description>
```

 If I comment Line 182, https://github.com/am11/WebEssentials2013/commit/51a4dc19c645d13916aead665cd23090bb1be81c#diff-00aefb51dd4d31ae7e5d08d7d8ee2a66R181, the exception is gone, but then it doesn't update the b64 dataUri (only the comment).

Can we suppress this first-run exception?
</del>
