### PR TITLE
LESS: Prevent the reference to the css.map

### DIFF
--- a/EditorExtensions/LESS/Compilers/LessCompiler.cs
+++ b/EditorExtensions/LESS/Compilers/LessCompiler.cs
@@ -26,9 +26,15 @@ namespace MadsKristensen.EditorExtensions.Less
             MapFileName = GenerateSourceMap ? MapFileName : Path.Combine(Path.GetTempPath(), Path.GetFileName(MapFileName));
 
             string mapDirectory = Path.GetDirectoryName(MapFileName);
-
-            return string.Format(CultureInfo.CurrentCulture, "--no-color --relative-urls --source-map-basepath=\"{0}\" --source-map=\"{1}\" \"{2}\" \"{3}\"",
-                                 mapDirectory, MapFileName, sourceFileName, targetFileName);
+            if (WESettings.Instance.Less.GenerateSourceMaps)
+            {
+                return string.Format(CultureInfo.CurrentCulture, "--no-color --relative-urls --source-map-basepath=\"{0}\" --source-map=\"{1}\" \"{2}\" \"{3}\"",
+                                     mapDirectory, MapFileName, sourceFileName, targetFileName);
+            }
+            else
+            {
+                return string.Format(CultureInfo.CurrentCulture, "--no-color --relative-urls \"{0}\" \"{1}\"", sourceFileName, targetFileName);
+            }
         }
     }
 }


### PR DESCRIPTION
LESS: Prevent the reference to the css.map in the css result if the option is disabled

If you disable the source map generation from less the css has the reference to the css.map. 
This happen because of the change in https://github.com/am11/WebEssentials2013/commit/5a826c7faa2a4f3c498150db06d3b505809313ae removing the check to `WESettings.Instance.Less.GenerateSourceMaps` before adding the `--source-map-basepath=\"{0}\" --source-map=\"{1}\"` to the less compiler command line.
