### PR TITLE
Bundle: Update all related files on change

### DIFF
--- a/EditorExtensions/Misc/MenuItems/ProjectSettings.cs
+++ b/EditorExtensions/Misc/MenuItems/ProjectSettings.cs
@@ -6,6 +6,7 @@ using EnvDTE;
 using EnvDTE80;
 using MadsKristensen.EditorExtensions.Settings;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace MadsKristensen.EditorExtensions
 {
@@ -27,12 +28,19 @@ namespace MadsKristensen.EditorExtensions
             menuCommandSol.BeforeQueryStatus += SolutionBeforeQueryStatus;
             _mcs.AddCommand(menuCommandSol);
 
+            _dte.Events.SolutionEvents.Opened += SolutionEvents_Opened;
+
             ProjectItemsEvents projectEvents = ((Events2)_dte.Events).ProjectItemsEvents;
             projectEvents.ItemRemoved += ItemRemoved;
             projectEvents.ItemRenamed += ItemRenamed;
 
             SolutionEvents solutionEvents = ((Events2)_dte.Events).SolutionEvents;
             solutionEvents.ProjectRemoved += ProjectRemoved;
+        }
+
+        void SolutionEvents_Opened()
+        {
+            System.Threading.Tasks.Task.Run(() => BundleFilesMenu.BindAllBundlesAssets(_dte.Solution.FullName));
         }
 
         private void SolutionBeforeQueryStatus(object sender, EventArgs e)


### PR DESCRIPTION
This fixes part of issue #842, which deals with Web Essentials' bundles. 

In TypeScript project using `Combine JavaScript output into file` option, the same issue exists, which should be solved by TypeScript team.
