### PR TITLE
Helpers: Robust logic for getting solution folder.

### DIFF
--- a/EditorExtensions/Misc/MenuItems/ProjectSettings.cs
+++ b/EditorExtensions/Misc/MenuItems/ProjectSettings.cs
@@ -39,7 +39,7 @@ namespace MadsKristensen.EditorExtensions
 
         void SolutionEvents_Opened()
         {
-            System.Threading.Tasks.Task.Run(() => BundleFilesMenu.BindAllBundlesAssets(_dte.Solution.FullName));
+            System.Threading.Tasks.Task.Run(() => BundleFilesMenu.BindAllBundlesAssets(ProjectHelpers.GetSolutionFolderPath()));
         }
 
         private void SolutionBeforeQueryStatus(object sender, EventArgs e)

--- a/EditorExtensions/Shared/Helpers/ProjectHelpers.cs
+++ b/EditorExtensions/Shared/Helpers/ProjectHelpers.cs
@@ -334,8 +334,11 @@ namespace MadsKristensen.EditorExtensions
         {
             EnvDTE.Solution solution = EditorExtensionsPackage.DTE.Solution;
 
-            if (solution == null || string.IsNullOrEmpty(solution.FullName))
+            if (solution == null)
                 return null;
+
+            if (string.IsNullOrEmpty(solution.FullName))
+                return GetRootFolder();
 
             return Path.GetDirectoryName(solution.FullName);
         }


### PR DESCRIPTION
In website project, `Solution.FullName` is empty.
Instead of returning null, calling `GetRootFolder`
method without parameter also finds solution's
root path.

It was breaking with bundle file-watcher, on
loading solution.
