### PR TITLE
[TypeScript] Change for generated files

### DIFF
--- a/EditorExtensions/Misc/CodeGeneration/IntellisenseParser.cs
+++ b/EditorExtensions/Misc/CodeGeneration/IntellisenseParser.cs
@@ -190,6 +190,14 @@ namespace MadsKristensen.EditorExtensions
         {
             var references = new HashSet<string>();
             var properties = GetProperties(cc.Members, new HashSet<string>(), references).ToList();
+            var internalEnums = cc.Members.OfType<CodeEnum>().ToList();
+            if (internalEnums != null)
+            {
+                foreach (var internalEnum in internalEnums)
+                {
+                    ProcessEnum(internalEnum, list);
+                }
+            }
             var dataContractAttribute = cc.Attributes.Cast<CodeAttribute>().Where(a => a.Name == "DataContract");
             string className = cc.Name;
             string nsName = GetNamespace(cc);

--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -95,6 +95,16 @@ namespace MadsKristensen.EditorExtensions.Settings
         [Description("Use LowerCamelCase instead of lowerCamelCase for type names in generated JS/TS files.")]
         [DefaultValue(false)]
         public bool CamelCaseTypeNames { get; set; }
+
+        [DisplayName("Use LowerCamelCase for enumeration values")]
+        [Description("Use LowerCamelCase for enumeration values in generated JS/TS files.")]
+        [DefaultValue(false)]
+        public bool CamelCaseEnumerationValues { get; set; }
+
+        [DisplayName("Add TypeScript reference")]
+        [Description("Add TypeScript reference path in generated JS/TS files.")]
+        [DefaultValue(true)]
+        public bool AddTypeScriptReferencePath { get; set; }
     }
 
     public interface ILinterSettings


### PR DESCRIPTION
- Fix for nested enum in class
- Fix for the reference path that can be duplicated
- Add a config option to enable/disable camelCasing for enum values
- Add a config option to add TypeScript reference path in .d.ts files

Fix for nested file, if you have a class like this: 

``` c#
    class Car
    {
        public string Name { get; set; }
        public Color Color { get; set; }
        internal enum Color { Red, Blue }
    }
```

Curently generate: 

``` c#
declare module server {
    interface Car {
        Name: string;
        Color: server.Color;
    }
}
```

server.Color is not defined in the server module, intellisense raise an error.
Now it generate this:

``` c#
declare module server {
    enum Color {
        Red,
        Blue,
    }
    interface Car {
        name: string;
        color: server.Color;
    }
}
```

---

BTW: I've notice that the IntellisenseParser and the ScriptIntellisenseListener share the same code listening to the change on the file. This cause the c# class to be generated in typescript (or javascript) twice. I have made the change in a separated branch on my repo you can see here https://github.com/gcastre/WebEssentials2013/commit/129251e52791f26df027c6af3c5936422a56c1f7
