### PR TITLE
FileHelpers: Tolerates transient IO errors

### DIFF
--- a/EditorExtensions/BrowserLink/BestPractices/Rules/Description.cs
+++ b/EditorExtensions/BrowserLink/BestPractices/Rules/Description.cs
@@ -34,7 +34,7 @@ namespace MadsKristensen.EditorExtensions
             get { return TaskErrorCategory.Warning; }
         }
 
-        public void Navigate(object sender, EventArgs e)
+        public async void Navigate(object sender, EventArgs e)
         {
             ErrorTask task = (ErrorTask)sender;
 
@@ -43,7 +43,7 @@ namespace MadsKristensen.EditorExtensions
                 if (!File.Exists(_file))
                     return;
 
-                string html = File.ReadAllText(_file);
+                string html = await FileHelpers.ReadAllTextRetry(_file);
                 int index = html.IndexOf("</head>", StringComparison.OrdinalIgnoreCase);
 
                 if (index > -1)

--- a/EditorExtensions/BrowserLink/BestPractices/Rules/Viewport.cs
+++ b/EditorExtensions/BrowserLink/BestPractices/Rules/Viewport.cs
@@ -33,7 +33,7 @@ namespace MadsKristensen.EditorExtensions
             get { return TaskErrorCategory.Warning; }
         }
 
-        public void Navigate(object sender, EventArgs e)
+        public async void Navigate(object sender, EventArgs e)
         {
             ErrorTask task = (ErrorTask)sender;
 
@@ -42,7 +42,7 @@ namespace MadsKristensen.EditorExtensions
                 if (!File.Exists(_file))
                     return;
 
-                string html = File.ReadAllText(_file);
+                string html = await FileHelpers.ReadAllTextRetry(_file);
                 int index = html.IndexOf("</head>", StringComparison.OrdinalIgnoreCase);
 
                 if (index > -1)

--- a/EditorExtensions/BrowserLink/UnusedCss/DocumentBase.cs
+++ b/EditorExtensions/BrowserLink/UnusedCss/DocumentBase.cs
@@ -84,7 +84,7 @@ namespace MadsKristensen.EditorExtensions.BrowserLink.UnusedCss
             {
                 try
                 {
-                    var text = File.ReadAllText(_file);
+                    var text = await FileHelpers.ReadAllTextRetry(_file);
 
                     Reparse(text);
 

--- a/EditorExtensions/CSS/NavigateTo/CssGoToLineProvider.cs
+++ b/EditorExtensions/CSS/NavigateTo/CssGoToLineProvider.cs
@@ -47,10 +47,10 @@ namespace MadsKristensen.EditorExtensions.Css
                     parallelOptions.CancellationToken = _cancellationToken;
                     parallelOptions.MaxDegreeOfParallelism = Environment.ProcessorCount;
 
-                    Parallel.For(0, fileList.Count, parallelOptions, i =>
+                    Parallel.For(0, fileList.Count, parallelOptions, async i =>
                     {
                         string file = fileList[i];
-                        IEnumerable<ParseItem> items = GetItems(file, _searchValue);
+                        IEnumerable<ParseItem> items = await GetItems(file, _searchValue);
                         foreach (ParseItem sel in items)
                         {
                             _cancellationToken.ThrowIfCancellationRequested();
@@ -72,10 +72,10 @@ namespace MadsKristensen.EditorExtensions.Css
                 }
             }
 
-            private static IEnumerable<ParseItem> GetItems(string filePath, string searchValue)
+            private async static Task<IEnumerable<ParseItem>> GetItems(string filePath, string searchValue)
             {
                 var cssParser = new CssParser();
-                StyleSheet ss = cssParser.Parse(File.ReadAllText(filePath), true);
+                StyleSheet ss = cssParser.Parse(await FileHelpers.ReadAllTextRetry(filePath), true);
 
                 return new CssItemAggregator<ParseItem>
                 {

--- a/EditorExtensions/CSS/SmartTags/Actions/ReverseEmbedSmartTagAction.cs
+++ b/EditorExtensions/CSS/SmartTags/Actions/ReverseEmbedSmartTagAction.cs
@@ -27,7 +27,7 @@ namespace MadsKristensen.EditorExtensions.Css
             get { return Resources.ReverseEmbedSmartTagActionName; }
         }
 
-        public override void Invoke()
+        public async override void Invoke()
         {
             string base64 = _url.UrlString.Text.Trim('\'', '"');
             string mimeType = FileHelpers.GetMimeTypeFromBase64(base64);
@@ -35,7 +35,7 @@ namespace MadsKristensen.EditorExtensions.Css
 
             var fileName = FileHelpers.ShowDialog(extension);
 
-            if (!string.IsNullOrEmpty(fileName) && FileHelpers.SaveDataUriToFile(base64, fileName))
+            if (!string.IsNullOrEmpty(fileName) && await FileHelpers.SaveDataUriToFile(base64, fileName))
             {
                 using (EditorExtensionsPackage.UndoContext((DisplayText)))
                     ReplaceUrlValue(fileName);

--- a/EditorExtensions/CoffeeScript/Compilers/CoffeeScriptCompiler.cs
+++ b/EditorExtensions/CoffeeScript/Compilers/CoffeeScriptCompiler.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using MadsKristensen.EditorExtensions.Settings;
 using Microsoft.VisualStudio.Utilities;
 
@@ -36,11 +37,24 @@ namespace MadsKristensen.EditorExtensions.CoffeeScript
             return args.ToString();
         }
 
-        protected override string PostProcessResult(string resultSource, string sourceFileName, string targetFileName)
+        protected async override Task MoveOutputContentToCorrectTarget(string targetFileName)
+        {
+            if (!targetFileName.EndsWith(".min.js", System.StringComparison.OrdinalIgnoreCase))
+                return;
+
+            var tempName = targetFileName.Replace(".min.js", ".js");
+
+            if (!File.Exists(tempName))
+                return;
+
+            await FileHelpers.WriteAllTextRetry(targetFileName, await FileHelpers.ReadAllTextRetry(tempName));
+        }
+
+        protected async override Task<string> PostProcessResult(string resultSource, string sourceFileName, string targetFileName)
         {
             Logger.Log(ServiceName + ": " + Path.GetFileName(sourceFileName) + " compiled.");
 
-            return resultSource;
+            return await Task.FromResult(resultSource);
         }
     }
 }

--- a/EditorExtensions/EditorExtensionsPackage.cs
+++ b/EditorExtensions/EditorExtensionsPackage.cs
@@ -164,14 +164,14 @@ namespace MadsKristensen.EditorExtensions
         {
             var compiler = WebEditor.Host.ExportProvider.GetExport<ProjectCompiler>();
 
-            ThreadingTask.Task.Run(() =>
+            ThreadingTask.Task.Run(async () =>
             {
                 Parallel.ForEach(
                     Mef.GetSupportedContentTypes<ICompilerRunnerProvider>()
                        .Where(c => WESettings.Instance.ForContentType<ICompilerInvocationSettings>(c).CompileOnBuild),
                     c => compiler.Value.CompileSolutionAsync(c).DontWait("compiling solution-wide " + c.DisplayName)
                 );
-                BuildMenu.UpdateBundleFiles();
+                await BuildMenu.UpdateBundleFiles();
             }).DontWait("running solution-wide compilers");
 
             if (WESettings.Instance.JavaScript.LintOnBuild)

--- a/EditorExtensions/HTML/Commands/GoToDefinitionCommandTarget.cs
+++ b/EditorExtensions/HTML/Commands/GoToDefinitionCommandTarget.cs
@@ -87,7 +87,7 @@ namespace MadsKristensen.EditorExtensions.Html
                     if (file.EndsWith(".min" + ext, StringComparison.OrdinalIgnoreCase))
                         continue;
 
-                    string text = File.ReadAllText(file);
+                    string text = FileHelpers.ReadAllTextRetry(file).ConfigureAwait(false).GetAwaiter().GetResult();
                     int index = text.IndexOf("." + _className, StringComparison.Ordinal);
 
                     if (index > -1)

--- a/EditorExtensions/HTML/SmartTags/Base64DecodeSmartTag.cs
+++ b/EditorExtensions/HTML/SmartTags/Base64DecodeSmartTag.cs
@@ -60,7 +60,7 @@ namespace MadsKristensen.EditorExtensions.Html
                 base(htmlSmartTag, "Save as image")
             { }
 
-            public override void Invoke()
+            public async override void Invoke()
             {
                 ITextBuffer textBuffer = this.HtmlSmartTag.TextBuffer;
                 ElementNode element = this.HtmlSmartTag.Element;
@@ -71,7 +71,7 @@ namespace MadsKristensen.EditorExtensions.Html
 
                 var fileName = FileHelpers.ShowDialog(extension);
 
-                if (!string.IsNullOrEmpty(fileName) && FileHelpers.SaveDataUriToFile(src.Value, fileName))
+                if (!string.IsNullOrEmpty(fileName) && await FileHelpers.SaveDataUriToFile(src.Value, fileName))
                 {
                     using (EditorExtensionsPackage.UndoContext((DisplayText)))
                         ReplaceUrlValue(fileName, textBuffer, src);

--- a/EditorExtensions/HTML/SmartTags/ExtractToFileSmartTag.cs
+++ b/EditorExtensions/HTML/SmartTags/ExtractToFileSmartTag.cs
@@ -1,8 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Globalization;
-using System.IO;
-using System.Text;
+using System.Threading.Tasks;
 using System.Web;
 using System.Windows.Forms;
 using Microsoft.Html.Core;
@@ -49,14 +48,14 @@ namespace MadsKristensen.EditorExtensions.Html
                 base(htmlSmartTag, "Extract To File")
             { }
 
-            public override void Invoke()
+            public async override void Invoke()
             {
                 string file;
                 string root = ProjectHelpers.GetProjectFolder(EditorExtensionsPackage.DTE.ActiveDocument.FullName);
 
                 if (CanSaveFile(root, out file))
                 {
-                    MakeChanges(root, file);
+                    await MakeChanges(root, file);
                 }
             }
 
@@ -82,7 +81,7 @@ namespace MadsKristensen.EditorExtensions.Html
                 return true;
             }
 
-            private void MakeChanges(string root, string fileName)
+            private async Task MakeChanges(string root, string fileName)
             {
                 var element = this.HtmlSmartTag.Element;
                 var textBuffer = this.HtmlSmartTag.TextBuffer;
@@ -93,7 +92,7 @@ namespace MadsKristensen.EditorExtensions.Html
                 using (EditorExtensionsPackage.UndoContext((this.DisplayText)))
                 {
                     textBuffer.Replace(new Span(element.Start, element.Length), reference);
-                    File.WriteAllText(fileName, text, Encoding.UTF8);
+                    await FileHelpers.WriteAllTextRetry(fileName, text);
                     EditorExtensionsPackage.DTE.ItemOperations.OpenFile(fileName);
                     ProjectHelpers.AddFileToActiveProject(fileName);
                 }

--- a/EditorExtensions/HTML/SmartTags/HtmlAngularControllerSmartTag.cs
+++ b/EditorExtensions/HTML/SmartTags/HtmlAngularControllerSmartTag.cs
@@ -2,7 +2,6 @@
 using System.ComponentModel.Composition;
 using System.Globalization;
 using System.IO;
-using System.Text;
 using System.Windows.Forms;
 using Microsoft.Html.Core;
 using Microsoft.Html.Editor.SmartTags;
@@ -49,7 +48,7 @@ namespace MadsKristensen.EditorExtensions.Html
                 base(htmlSmartTag, "Add new Angular controller")
             { }
 
-            public override void Invoke()
+            public async override void Invoke()
             {
                 string value = HtmlSmartTag.Element.GetAttribute("ng-controller").Value;
 
@@ -75,7 +74,7 @@ namespace MadsKristensen.EditorExtensions.Html
                 using (EditorExtensionsPackage.UndoContext((this.DisplayText)))
                 {
                     string script = GetScript(value);
-                    File.WriteAllText(file, script, Encoding.UTF8);
+                    await FileHelpers.WriteAllTextRetry(file, script);
 
                     ProjectHelpers.AddFileToActiveProject(file);
                     EditorExtensionsPackage.DTE.ItemOperations.OpenFile(file);

--- a/EditorExtensions/Images/Commands/PasteImageCommandTarget.cs
+++ b/EditorExtensions/Images/Commands/PasteImageCommandTarget.cs
@@ -209,7 +209,7 @@ namespace MadsKristensen.EditorExtensions.Images
                 {
                     image.Save(ms, GetImageFormat(Path.GetExtension(fileName)));
                     byte[] buffer = ms.ToArray();
-                    File.WriteAllBytes(fileName, buffer);
+                    await FileHelpers.WriteAllBytesRetry(fileName, buffer);
                 }
             }
 

--- a/EditorExtensions/Images/Compression/ImageCompressor.cs
+++ b/EditorExtensions/Images/Compression/ImageCompressor.cs
@@ -26,12 +26,12 @@ namespace MadsKristensen.EditorExtensions.Images
                 return dataUri;
 
             string temp = Path.Combine(Path.GetTempPath(), _dataUriPrefix + Guid.NewGuid() + "." + extension);
-            bool isFileSaved = FileHelpers.SaveDataUriToFile(dataUri, temp);
+            bool isFileSaved = await FileHelpers.SaveDataUriToFile(dataUri, temp);
 
             if (isFileSaved)
             {
                 await CompressFilesAsync(temp);
-                string base64 = FileHelpers.ConvertToBase64(temp);
+                string base64 = await FileHelpers.ConvertToBase64(temp);
                 File.Delete(temp);
 
                 return base64;

--- a/EditorExtensions/Images/MenuItems/SpriteImage.cs
+++ b/EditorExtensions/Images/MenuItems/SpriteImage.cs
@@ -111,7 +111,7 @@ namespace MadsKristensen.EditorExtensions.Images
             ProjectHelpers.AddFileToActiveProject(sprite.FileName);
             ProjectHelpers.AddFileToProject(sprite.FileName, imageFile);
 
-            Export(fragments, imageFile);
+            await Export(fragments, imageFile);
 
             if (sprite.Optimize)
                 await new ImageCompressor().CompressFilesAsync(imageFile);
@@ -119,11 +119,11 @@ namespace MadsKristensen.EditorExtensions.Images
             _dte.StatusBar.Text = "Sprite generated";
         }
 
-        private static void Export(IEnumerable<SpriteFragment> fragments, string imageFile)
+        private async static Task Export(IEnumerable<SpriteFragment> fragments, string imageFile)
         {
             foreach (ExportFormat format in (ExportFormat[])Enum.GetValues(typeof(ExportFormat)))
             {
-                string exportFile = SpriteExporter.Export(fragments, imageFile, format);
+                string exportFile = await SpriteExporter.Export(fragments, imageFile, format);
                 ProjectHelpers.AddFileToProject(imageFile, exportFile);
             }
         }

--- a/EditorExtensions/Images/Sprite/SpriteExporter.cs
+++ b/EditorExtensions/Images/Sprite/SpriteExporter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -10,14 +11,14 @@ namespace MadsKristensen.EditorExtensions.Images
 {
     internal class SpriteExporter
     {
-        public static string Export(IEnumerable<SpriteFragment> fragments, string imageFile, ExportFormat format)
+        public async static Task<string> Export(IEnumerable<SpriteFragment> fragments, string imageFile, ExportFormat format)
         {
             if (format == ExportFormat.Json)
             {
                 return ExportJson(fragments, imageFile);
             }
 
-            return ExportStylesheet(fragments, imageFile, format);
+            return await ExportStylesheet(fragments, imageFile, format);
         }
 
         private static string ExportJson(IEnumerable<SpriteFragment> fragments, string imageFile)
@@ -55,7 +56,7 @@ namespace MadsKristensen.EditorExtensions.Images
             return outputFile;
         }
 
-        private static string ExportStylesheet(IEnumerable<SpriteFragment> fragments, string imageFile, ExportFormat format)
+        private async static Task<string> ExportStylesheet(IEnumerable<SpriteFragment> fragments, string imageFile, ExportFormat format)
         {
             StringBuilder sb = new StringBuilder();
             sb.AppendLine(GetDescription(format));
@@ -73,7 +74,7 @@ namespace MadsKristensen.EditorExtensions.Images
             string outputFile = GetFileName(imageFile, format);
 
             ProjectHelpers.CheckOutFileFromSourceControl(outputFile);
-            File.WriteAllText(outputFile, sb.ToString().Replace("-0px", "0"), Encoding.UTF8);
+            await FileHelpers.WriteAllTextRetry(outputFile, sb.ToString().Replace("-0px", "0"));
 
             return outputFile;
         }

--- a/EditorExtensions/JavaScript/Commands/NodeModuleGoToDefinition.cs
+++ b/EditorExtensions/JavaScript/Commands/NodeModuleGoToDefinition.cs
@@ -21,7 +21,7 @@ namespace MadsKristensen.EditorExtensions.JavaScript
             if (path == null)
                 return false;
 
-            var filePath = NodeModuleService.ResolveModule(Path.GetDirectoryName(TextView.TextBuffer.GetFileName()), path);
+            var filePath = NodeModuleService.ResolveModule(Path.GetDirectoryName(TextView.TextBuffer.GetFileName()), path).ConfigureAwait(false).GetAwaiter().GetResult();
 
             if (filePath != null)
             {

--- a/EditorExtensions/JavaScript/Linters/JsHintCompiler.cs
+++ b/EditorExtensions/JavaScript/Linters/JsHintCompiler.cs
@@ -58,9 +58,9 @@ namespace MadsKristensen.EditorExtensions.JavaScript
                                , sourceFileName);
         }
 
-        protected override string PostProcessResult(string resultSource, string sourceFileName, string targetFileName)
+        protected async override Task<string> PostProcessResult(string resultSource, string sourceFileName, string targetFileName)
         {
-            return resultSource;
+            return await Task.FromResult(resultSource);
         }
     }
 }

--- a/EditorExtensions/JavaScript/MenuItems/ReferenceJs.cs
+++ b/EditorExtensions/JavaScript/MenuItems/ReferenceJs.cs
@@ -2,7 +2,6 @@
 using System.ComponentModel.Design;
 using System.IO;
 using System.Linq;
-using System.Text;
 using Microsoft.VisualStudio.Shell;
 
 namespace MadsKristensen.EditorExtensions.JavaScript
@@ -20,7 +19,7 @@ namespace MadsKristensen.EditorExtensions.JavaScript
         public void SetupCommands()
         {
             CommandID commandId = new CommandID(CommandGuids.guidEditorExtensionsCmdSet, (int)CommandId.ReferenceJs);
-            OleMenuCommand menuCommand = new OleMenuCommand((s, e) => Execute(), commandId);
+            OleMenuCommand menuCommand = new OleMenuCommand(async (s, e) => await Execute(), commandId);
             menuCommand.BeforeQueryStatus += menuCommand_BeforeQueryStatus;
             _mcs.AddCommand(menuCommand);
         }
@@ -60,12 +59,12 @@ namespace MadsKristensen.EditorExtensions.JavaScript
             menuCommand.Visible = true;
         }
 
-        private void Execute()
+        private async System.Threading.Tasks.Task Execute()
         {
             try
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(_referencesJsPath));
-                File.WriteAllText(_referencesJsPath, "/// <autosync enabled=\"true\" />", Encoding.UTF8);
+                await FileHelpers.WriteAllTextRetry(_referencesJsPath, "/// <autosync enabled=\"true\" />");
                 ProjectHelpers.AddFileToActiveProject(_referencesJsPath);
                 EditorExtensionsPackage.DTE.ItemOperations.OpenFile(_referencesJsPath);
             }

--- a/EditorExtensions/Markdown/Margin/MarkdownMargin.cs
+++ b/EditorExtensions/Markdown/Margin/MarkdownMargin.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Globalization;
 using System.IO;
-using System.Text;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using MadsKristensen.EditorExtensions.Settings;
@@ -44,13 +44,12 @@ namespace MadsKristensen.EditorExtensions.Markdown
             return Path.Combine(folder, _stylesheet);
         }
 
-        public static void CreateStylesheet()
+        public async static Task CreateStylesheet()
         {
             string file = Path.Combine(ProjectHelpers.GetSolutionFolderPath(), _stylesheet);
-            File.WriteAllText(file, "body { background: yellow; }", new UTF8Encoding(true));
+            await FileHelpers.WriteAllTextRetry(file, "body { background: yellow; }");
             ProjectHelpers.GetSolutionItemsProject().ProjectItems.AddFromFile(file);
         }
-
 
         protected override void UpdateMargin(CompilerResult result)
         {

--- a/EditorExtensions/Markdown/MenuItems/Markdown.cs
+++ b/EditorExtensions/Markdown/MenuItems/Markdown.cs
@@ -38,7 +38,7 @@ namespace MadsKristensen.EditorExtensions.Markdown
         public void SetupCommands()
         {
             CommandID css = new CommandID(CommandGuids.guidDiffCmdSet, (int)CommandId.CreateMarkdownStylesheet);
-            OleMenuCommand cssCommand = new OleMenuCommand((s, e) => AddStylesheet(), css);
+            OleMenuCommand cssCommand = new OleMenuCommand(async (s, e) => await AddStylesheet(), css);
             cssCommand.BeforeQueryStatus += HasStylesheet;
             _mcs.AddCommand(cssCommand);
 
@@ -72,9 +72,9 @@ namespace MadsKristensen.EditorExtensions.Markdown
             Parallel.ForEach(paths, f => compiler.CompileToDefaultOutputAsync(f).DontWait("compiling " + f));
         }
 
-        private static void AddStylesheet()
+        private async static System.Threading.Tasks.Task AddStylesheet()
         {
-            MarkdownMargin.CreateStylesheet();
+            await MarkdownMargin.CreateStylesheet();
         }
     }
 }

--- a/EditorExtensions/Misc/CodeGeneration/IntellisenseParser.cs
+++ b/EditorExtensions/Misc/CodeGeneration/IntellisenseParser.cs
@@ -82,21 +82,21 @@ namespace MadsKristensen.EditorExtensions
                 if (list == null)
                     return false;
 
-                AddScript(filePath, Ext.JavaScript, list);
-                AddScript(filePath, Ext.TypeScript, list);
+                Task.FromResult(AddScript(filePath, Ext.JavaScript, list));
+                Task.FromResult(AddScript(filePath, Ext.TypeScript, list));
 
                 return true;
             }), DispatcherPriority.ApplicationIdle).Task;
         }
 
-        private static void AddScript(string filePath, string extension, IEnumerable<IntellisenseObject> list)
+        private async static Task AddScript(string filePath, string extension, IEnumerable<IntellisenseObject> list)
         {
             string resultPath = filePath + extension;
 
             if (!File.Exists(resultPath))
                 return;
 
-            IntellisenseWriter.Write(list, resultPath);
+            await IntellisenseWriter.Write(list, resultPath);
 
             var item = ProjectHelpers.AddFileToProject(filePath, resultPath);
 

--- a/EditorExtensions/Misc/CodeGeneration/IntellisenseWriter.cs
+++ b/EditorExtensions/Misc/CodeGeneration/IntellisenseWriter.cs
@@ -6,13 +6,14 @@ using System.Linq;
 using System.Security;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using MadsKristensen.EditorExtensions.Settings;
 
 namespace MadsKristensen.EditorExtensions
 {
     internal static class IntellisenseWriter
     {
-        public static void Write(IEnumerable<IntellisenseObject> objects, string file)
+        public async static Task Write(IEnumerable<IntellisenseObject> objects, string file)
         {
             StringBuilder sb = new StringBuilder();
 
@@ -21,7 +22,7 @@ namespace MadsKristensen.EditorExtensions
             else
                 WriteJavaScript(objects, sb);
 
-            File.WriteAllText(file, sb.ToString(), Encoding.UTF8);
+            await FileHelpers.WriteAllTextRetry(file, sb.ToString());
         }
 
         private static string CamelCasePropertyName(string name)

--- a/EditorExtensions/Misc/CodeGeneration/ScriptIntellisenseListener.cs
+++ b/EditorExtensions/Misc/CodeGeneration/ScriptIntellisenseListener.cs
@@ -65,22 +65,22 @@ namespace MadsKristensen.EditorExtensions
                 if (list == null)
                     return false;
 
-                AddScript(filePath, IntellisenseParser.Ext.JavaScript, list);
-                AddScript(filePath, IntellisenseParser.Ext.TypeScript, list);
+                Task.FromResult(AddScript(filePath, IntellisenseParser.Ext.JavaScript, list));
+                Task.FromResult(AddScript(filePath, IntellisenseParser.Ext.TypeScript, list));
 
                 return true;
             }), DispatcherPriority.ApplicationIdle).Task;
         }
 
 
-        private static void AddScript(string filePath, string extension, List<IntellisenseObject> list)
+        private async static Task AddScript(string filePath, string extension, List<IntellisenseObject> list)
         {
             string resultPath = filePath + extension;
 
             if (!File.Exists(resultPath))
                 return;
 
-            IntellisenseWriter.Write(list, resultPath);
+            await IntellisenseWriter.Write(list, resultPath);
 
             var item = ProjectHelpers.AddFileToProject(filePath, resultPath);
 

--- a/EditorExtensions/Misc/MenuItems/AddIntellisenseFile.cs
+++ b/EditorExtensions/Misc/MenuItems/AddIntellisenseFile.cs
@@ -63,7 +63,7 @@ namespace MadsKristensen.EditorExtensions
 
         protected async Task<bool> ExecuteAsync(string extension)
         {
-            File.WriteAllText(_file + extension, string.Empty);
+            await FileHelpers.WriteAllTextRetry(_file + extension, string.Empty);
             if (await ScriptIntellisenseListener.ProcessAsync(_file))
                 return true;
             File.Delete(_file + extension);

--- a/EditorExtensions/Misc/MenuItems/BuildMenu.cs
+++ b/EditorExtensions/Misc/MenuItems/BuildMenu.cs
@@ -9,7 +9,6 @@ using EnvDTE80;
 using MadsKristensen.EditorExtensions.Compilers;
 using MadsKristensen.EditorExtensions.Optimization.Minification;
 using MadsKristensen.EditorExtensions.SweetJs;
-using Microsoft.Html.Editor;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.Editor;
@@ -45,7 +44,7 @@ namespace MadsKristensen.EditorExtensions
             //TODO: Iced CoffeeScript?
 
             CommandID cmdBundles = new CommandID(CommandGuids.guidBuildCmdSet, (int)CommandId.BuildBundles);
-            OleMenuCommand menuBundles = new OleMenuCommand((s, e) => UpdateBundleFiles(), cmdBundles);
+            OleMenuCommand menuBundles = new OleMenuCommand(async (s, e) => await UpdateBundleFiles(), cmdBundles);
             _mcs.AddCommand(menuBundles);
 
             CommandID cmdMinify = new CommandID(CommandGuids.guidBuildCmdSet, (int)CommandId.BuildMinify);
@@ -66,9 +65,9 @@ namespace MadsKristensen.EditorExtensions
             _mcs.AddCommand(command);
         }
 
-        public static void UpdateBundleFiles()
+        public async static Task UpdateBundleFiles()
         {
-            BundleFilesMenu.UpdateBundles(null, true);
+            await BundleFilesMenu.UpdateBundles(null, true);
         }
 
         private void Minify()
@@ -85,8 +84,8 @@ namespace MadsKristensen.EditorExtensions
                             .Where(f => extensions.Contains(Path.GetExtension(f)));
 
             // Perform expensive blocking work in parallel
-            Parallel.ForEach(files, file =>
-                MinificationSaveListener.ReMinify(
+            Parallel.ForEach(files, async file =>
+                await MinificationSaveListener.ReMinify(
                     FileExtensionRegistry.GetContentTypeForExtension(Path.GetExtension(file).TrimStart('.')),
                     file,
                     false

--- a/EditorExtensions/Misc/MenuItems/MinifyFile.cs
+++ b/EditorExtensions/Misc/MenuItems/MinifyFile.cs
@@ -45,7 +45,7 @@ namespace MadsKristensen.EditorExtensions
                 ContentType = contentType;
                 _sourceExtensions = FileExtensionRegistry.GetFileExtensionSet(contentType);
 
-                Command = new OleMenuCommand((s, e) => Execute(), new CommandID(CommandGuids.guidMinifyCmdSet, (int)id));
+                Command = new OleMenuCommand(async (s, e) => await Execute(), new CommandID(CommandGuids.guidMinifyCmdSet, (int)id));
                 Command.BeforeQueryStatus += (s, e) => CheckVisible();
             }
 
@@ -58,16 +58,15 @@ namespace MadsKristensen.EditorExtensions
                            );
                 Command.Enabled = selectedFiles.Any();
             }
-            private void Execute()
+            private async System.Threading.Tasks.Task Execute()
             {
                 foreach (var file in selectedFiles)
                 {
-                    MinificationSaveListener.CreateMinFile(ContentType, file);
+                    await MinificationSaveListener.CreateMinFile(ContentType, file);
                 }
 
                 CheckEnableSync();
             }
-
 
             private void CheckEnableSync()
             {

--- a/EditorExtensions/SCSS/Compilers/ScssCompiler.cs
+++ b/EditorExtensions/SCSS/Compilers/ScssCompiler.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using MadsKristensen.EditorExtensions.Settings;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.Editor;
@@ -30,9 +31,9 @@ namespace MadsKristensen.EditorExtensions.Scss
         }
 
         //https://github.com/hcatlin/libsass/issues/242
-        protected override string ReadMapFile(string sourceMapFileName)
+        protected async override Task<string> ReadMapFile(string sourceMapFileName)
         {
-            return File.ReadAllText(sourceMapFileName).Replace("\\", "\\\\");
+            return (await FileHelpers.ReadAllTextRetry(sourceMapFileName)).Replace("\\", "\\\\");
         }
     }
 }

--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -180,7 +180,7 @@ namespace MadsKristensen.EditorExtensions.Settings
         public string HtmlFormat { get; set; }
     }
 
-    public sealed class JavaScriptSettings : LinterSettings<JavaScriptSettings>, IMinifierSettings
+    public sealed class JavaScriptSettings : LinterSettings<JavaScriptSettings>, IMinifierSettings, ISourceMapSettings
     {
         #region Minification
         [Category("Minification")]
@@ -295,7 +295,7 @@ namespace MadsKristensen.EditorExtensions.Settings
         public bool ShowBrowserTooltip { get; set; }
     }
 
-    public abstract class CompilationSettings<T> : SettingsBase<T>, ICompilerInvocationSettings, IMarginSettings where T : CompilationSettings<T>
+    public abstract class CompilationSettings<T> : SettingsBase<T>, ICompilerInvocationSettings, IMarginSettings, ISourceMapSettings where T : CompilationSettings<T>
     {
         [Category("Editor")]
         [DisplayName("Show preview pane")]
@@ -459,6 +459,11 @@ namespace MadsKristensen.EditorExtensions.Settings
         public bool MinifyInPlace { get; set; }
     }
 
+    public interface ISourceMapSettings
+    {
+        bool GenerateSourceMaps { get; }
+    }
+
     public interface IMarginSettings
     {
         bool ShowPreviewPane { get; }
@@ -471,11 +476,13 @@ namespace MadsKristensen.EditorExtensions.Settings
         string OutputDirectory { get; }
         bool MinifyInPlace { get; }
     }
+
     public interface IChainableCompilerSettings : ICompilerInvocationSettings
     {
         bool EnableChainCompilation { get; }
         event EventHandler EnableChainCompilationChanged;
     }
+
     public interface IMinifierSettings
     {
         bool AutoMinify { get; set; }

--- a/EditorExtensions/Shared/Commands/IFileSaveListener.cs
+++ b/EditorExtensions/Shared/Commands/IFileSaveListener.cs
@@ -1,10 +1,11 @@
-﻿using Microsoft.VisualStudio.Utilities;
+﻿using System.Threading.Tasks;
+using Microsoft.VisualStudio.Utilities;
 
 namespace MadsKristensen.EditorExtensions.Commands
 {
     ///<summary>A listener called when files are saved in the editor, as well as for compiled files on save or build.</summary>
     public interface IFileSaveListener
     {
-        void FileSaved(IContentType contentType, string path, bool forceSave, bool minifyInPlace);
+        Task FileSaved(IContentType contentType, string path, bool forceSave, bool minifyInPlace);
     }
 }

--- a/EditorExtensions/Shared/Compilers/EditorCompilerInvoker.cs
+++ b/EditorExtensions/Shared/Compilers/EditorCompilerInvoker.cs
@@ -63,7 +63,7 @@ namespace MadsKristensen.EditorExtensions.Compilers
             return InitiateCompilationAsync(sourcePath, save: CompilerRunner.Settings.CompileOnSave).HandleErrors("compiling " + sourcePath);
         }
 
-        public void RequestCompilationResult(bool cached)
+        public async void RequestCompilationResult(bool cached)
         {
             if (cached && CompilerRunner.Settings.CompileOnSave)
             {
@@ -71,7 +71,7 @@ namespace MadsKristensen.EditorExtensions.Compilers
 
                 if (File.Exists(targetPath))
                 {
-                    OnCompilationReady(new CompilerResultEventArgs(CompilerResultFactory.GenerateResult(Document.FilePath, targetPath)));
+                    OnCompilationReady(new CompilerResultEventArgs(await CompilerResultFactory.GenerateResult(Document.FilePath, targetPath)));
 
                     return;
                 }

--- a/EditorExtensions/Shared/Compilers/Result/CompilerResultFactory.cs
+++ b/EditorExtensions/Shared/Compilers/Result/CompilerResultFactory.cs
@@ -1,32 +1,33 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace MadsKristensen.EditorExtensions
 {
     public static class CompilerResultFactory
     {
-        public static CompilerResult GenerateResult(string sourceFileName, string targetFileName)
+        public async static Task<CompilerResult> GenerateResult(string sourceFileName, string targetFileName)
         {
-            return GenerateResult(sourceFileName, targetFileName, null, true, null, null);
+            return await GenerateResult(sourceFileName, targetFileName, null, true, null, null);
         }
 
-        public static CompilerResult GenerateResult(string sourceFileName, string targetFileName, bool isSuccess, string result, IEnumerable<CompilerError> errors)
+        public async static Task<CompilerResult> GenerateResult(string sourceFileName, string targetFileName, bool isSuccess, string result, IEnumerable<CompilerError> errors)
         {
-            return GenerateResult(sourceFileName, targetFileName, null, isSuccess, result, errors);
+            return await GenerateResult(sourceFileName, targetFileName, null, isSuccess, result, errors);
         }
 
-        public static CompilerResult GenerateResult(string sourceFileName, string targetFileName, string mapFileName, bool isSuccess, string result, IEnumerable<CompilerError> errors)
+        public async static Task<CompilerResult> GenerateResult(string sourceFileName, string targetFileName, string mapFileName, bool isSuccess, string result, IEnumerable<CompilerError> errors)
         {
             CompilerResult instance;
 
             mapFileName = mapFileName ?? targetFileName + ".map";
 
             if (result == null && File.Exists(targetFileName))
-                result = File.ReadAllText(targetFileName);
+                result = await FileHelpers.ReadAllTextRetry(targetFileName);
 
             if (targetFileName != null && Path.GetExtension(targetFileName).Equals(".css", StringComparison.OrdinalIgnoreCase) && File.Exists(mapFileName))
-                instance = CssCompilerResult.GenerateResult(sourceFileName, targetFileName, mapFileName, isSuccess, result, errors);
+                instance = await CssCompilerResult.GenerateResult(sourceFileName, targetFileName, mapFileName, isSuccess, result, errors);
             else
                 instance = CompilerResult.GenerateResult(sourceFileName, targetFileName, isSuccess, result, errors);
 

--- a/EditorExtensions/Shared/Compilers/Result/CssCompilerResult.cs
+++ b/EditorExtensions/Shared/Compilers/Result/CssCompilerResult.cs
@@ -6,13 +6,14 @@ namespace MadsKristensen.EditorExtensions
 {
     public class CssCompilerResult : CompilerResult
     {
+        public string SourceMapData { get; set; }
         public Task<CssSourceMap> SourceMap { get; set; }
 
         private CssCompilerResult(string sourceFileName, string targetFileName, bool isSuccess, string result, IEnumerable<CompilerError> errors)
             : base(sourceFileName, targetFileName, isSuccess, result, errors)
         { }
 
-        public static CssCompilerResult GenerateResult(string sourceFileName, string targetFileName, string mapFileName, bool isSuccess, string result, IEnumerable<CompilerError> errors)
+        public async static Task<CssCompilerResult> GenerateResult(string sourceFileName, string targetFileName, string mapFileName, bool isSuccess, string result, IEnumerable<CompilerError> errors)
         {
             CssCompilerResult compilerResult = new CssCompilerResult(sourceFileName, targetFileName, isSuccess, result, errors);
 
@@ -20,7 +21,11 @@ namespace MadsKristensen.EditorExtensions
                 return null;
 
             var extension = Path.GetExtension(sourceFileName).TrimStart('.');
-            compilerResult.SourceMap = CssSourceMap.Create(targetFileName, mapFileName, Mef.GetContentType(extension));
+
+            compilerResult.SourceMap = CssSourceMap.Create(await FileHelpers.ReadAllTextRetry(targetFileName),
+                                                           await FileHelpers.ReadAllTextRetry(mapFileName),
+                                                           Path.GetDirectoryName(targetFileName),
+                                                           Mef.GetContentType(extension));
 
             return compilerResult;
         }

--- a/EditorExtensions/Shared/ExtensionMethods/Extensions.cs
+++ b/EditorExtensions/Shared/ExtensionMethods/Extensions.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 using ConfOxide.MemberAccess;
@@ -13,34 +11,6 @@ namespace MadsKristensen.EditorExtensions
 {
     static class Extensions
     {
-        ///<summary>Handles errors on a task to prevent VS from crashing.</summary>
-        ///<param name="operation">The description of the asynchronous operation to show in the log on failure.  Should start with a lowercase present-tense infinitive (eg,  "compiling someFile.less").</param>
-        /// <returns>A successful task, even if the operation fails.</returns>
-        ///<remarks>Call this method when aggregating async operations to report and ignore individual failures.</remarks>
-        public static Task HandleErrors(this Task task, string operation)
-        {
-            // Add the error handler, then return the original task.
-            // Don't wait on the continuation; it'll become canceled
-            // on success.  http://stackoverflow.com/q/6573720/34397
-            task.DontWait(operation);
-            return task;
-        }
-        ///<summary>Handles errors on a task to prevent VS from crashing.</summary>
-        ///<param name="operation">The description of the asynchronous operation to show in the log on failure.  Should start with a lowercase present-tense infinitive (eg,  "compiling someFile.less").</param>
-        ///<remarks>Call this method when you call an async method and don't need to wait for the result.</remarks>
-        public static void DontWait(this Task task, string operation)
-        {
-            if (SettingsStore.InTestMode)
-                return; // Don't mask crashes in unit tests.
-            task.ContinueWith(t =>
-            {
-                if (t.Exception == null)
-                    return;
-                Logger.Log("An exception was thrown when " + operation + ": "
-                         + string.Join(Environment.NewLine, t.Exception.InnerExceptions));
-            }, TaskContinuationOptions.OnlyOnFaulted);
-        }
-
         ///<summary>Returns a strongly-typed Settings object for the specified ContentType, or null if <see cref="WESettings"/> has no properties with that name (including base types) or type.</summary>
         ///<typeparam name="T">The interface to return.</typeparam>
         ///<remarks>
@@ -63,7 +33,6 @@ namespace MadsKristensen.EditorExtensions
                 return null;
             return typedProp.GetValue(settings);
         }
-
 
         ///<summary>Runs a callback when an iamge is fully downloaded, or immediately if the image has already been downloaded.</summary>
         public static void OnDownloaded(this BitmapSource image, Action callback)
@@ -119,22 +88,6 @@ namespace MadsKristensen.EditorExtensions
             if (count == intOccurrenceToFind) intReturn = n;
 
             return intReturn;
-        }
-
-        ///<summary>Execute process asynchronously.</summary>
-        public static Task<Process> ExecuteAsync(this ProcessStartInfo startInfo)
-        {
-            var process = Process.Start(startInfo);
-            var processTaskCompletionSource = new TaskCompletionSource<Process>();
-
-            process.EnableRaisingEvents = true;
-            process.Exited += (s, e) =>
-            {
-                process.WaitForExit();
-                processTaskCompletionSource.TrySetResult(process);
-            };
-
-            return processTaskCompletionSource.Task;
         }
     }
 }

--- a/EditorExtensions/Shared/ExtensionMethods/TaskExtensions/PolicyFactory.cs
+++ b/EditorExtensions/Shared/ExtensionMethods/TaskExtensions/PolicyFactory.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Microsoft.Practices.TransientFaultHandling;
+
+namespace MadsKristensen.EditorExtensions
+{
+    public class PolicyFactory
+    {
+        public static RetryPolicy GetPolicy(ITransientErrorDetectionStrategy strategy, int retryCount)
+        {
+            RetryPolicy policy = new RetryPolicy(strategy, retryCount, TimeSpan.FromMilliseconds(50));
+
+            return policy;
+        }
+    }
+}

--- a/EditorExtensions/Shared/ExtensionMethods/TaskExtensions/Strategies/FileTransientErrorDetectionStrategy.cs
+++ b/EditorExtensions/Shared/ExtensionMethods/TaskExtensions/Strategies/FileTransientErrorDetectionStrategy.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Microsoft.Practices.TransientFaultHandling;
+
+namespace MadsKristensen.EditorExtensions
+{
+    public class FileTransientErrorDetectionStrategy : ITransientErrorDetectionStrategy
+    {
+        public bool IsTransient(Exception ex)
+        {
+            return true;
+        }
+    }
+}

--- a/EditorExtensions/Shared/ExtensionMethods/TaskExtensions/TaskExtensions.cs
+++ b/EditorExtensions/Shared/ExtensionMethods/TaskExtensions/TaskExtensions.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using MadsKristensen.EditorExtensions.Settings;
+using Microsoft.Practices.TransientFaultHandling;
+
+namespace MadsKristensen.EditorExtensions
+{
+    public static class TaskExtensions
+    {
+        /// <summary>Handles errors on a task to prevent VS from crashing.</summary>
+        /// <param name="operation">The description of the asynchronous operation to show in the log on failure.  Should start with a lowercase present-tense infinitive (eg,  "compiling someFile.less").</param>
+        /// <returns>A successful task, even if the operation fails.</returns>
+        /// <remarks>Call this method when aggregating async operations to report and ignore individual failures.</remarks>
+        public static Task HandleErrors(this Task task, string operation)
+        {
+            // Add the error handler, then return the original task.
+            // Don't wait on the continuation; it'll become canceled
+            // on success.  http://stackoverflow.com/q/6573720/34397
+            task.DontWait(operation);
+            return task;
+        }
+
+        /// <summary>Handles errors on a task to prevent VS from crashing.</summary>
+        /// <param name="operation">The description of the asynchronous operation to show in the log on failure.  Should start with a lowercase present-tense infinitive (eg,  "compiling someFile.less").</param>
+        /// <remarks>Call this method when you call an async method and don't need to wait for the result.</remarks>
+        public static void DontWait(this Task task, string operation)
+        {
+            if (SettingsStore.InTestMode)
+                return; // Don't mask crashes in unit tests.
+            task.ContinueWith(t =>
+            {
+                if (t.Exception == null)
+                    return;
+                Logger.Log("An exception was thrown when " + operation + ": "
+                         + string.Join(Environment.NewLine, t.Exception.InnerExceptions));
+            }, TaskContinuationOptions.OnlyOnFaulted);
+        }
+
+        /// <summary>Execute task asynchronously.</summary>
+        public static Task<Process> ExecuteAsync(this ProcessStartInfo startInfo)
+        {
+            var process = Process.Start(startInfo);
+            var processTaskCompletionSource = new TaskCompletionSource<Process>();
+
+            process.EnableRaisingEvents = true;
+            process.Exited += (s, e) =>
+            {
+                process.WaitForExit();
+                processTaskCompletionSource.TrySetResult(process);
+            };
+
+            return processTaskCompletionSource.Task;
+        }
+
+        /// <summary>
+        /// Keep executing task asynchronously until successful execution
+        /// or the retry limit, set by the policy, is exausted.
+        /// </summary>
+        /// <param name="policy">The retry policy for task, can be manufactured by PolicyFactory.</param>
+        /// <returns>A successful task, even if the operation fails.</returns>
+        public async static Task ExecuteRetryableTaskAsync(this Task task, RetryPolicy policy)
+        {
+            await policy.ExecuteAsync(() => task);
+        }
+
+        /// <summary>
+        /// Keep executing task asynchronously until successful execution
+        /// or the retry limit, set by the policy, is exausted.
+        /// </summary>
+        /// <param name="policy">The retry policy for task, can be manufactured by PolicyFactory.</param>
+        /// <returns>A successful task, even if the operation fails.</returns>
+        public async static Task<T> ExecuteRetryableTaskAsync<T>(this Task<T> task, RetryPolicy policy) where T : class
+        {
+            return await policy.ExecuteAsync(() => task);
+        }
+    }
+}

--- a/EditorExtensions/Shared/Helpers/DependencyGraph.cs
+++ b/EditorExtensions/Shared/Helpers/DependencyGraph.cs
@@ -119,7 +119,8 @@ namespace MadsKristensen.EditorExtensions.Helpers
         #region Graph Creation
         ///<summary>Gets the full paths to all files that the given file depends on.  (the dependencies need not exist).</summary>
         ///<remarks>This method will be called concurrently on arbitrary threads.</remarks>
-        protected abstract IEnumerable<string> GetDependencyPaths(string fileName);
+        protected abstract Task<IEnumerable<string>> GetDependencyPaths(string fileName);
+
         ///<summary>Rescans the entire graph from a collection of source files, replacing the entire graph.</summary>
         ///<remarks>Although this method is async, it performs lots of synchronous work, and should not be called on a UI thread.</remarks>
         public async Task RescanAllAsync(IEnumerable<string> sourceFiles)
@@ -134,7 +135,7 @@ namespace MadsKristensen.EditorExtensions.Helpers
                 foreach (var item in dependencies)
                 {
                     var parentNode = GetNode(item.FileName);
-                    foreach (var dependency in item.dependencies)
+                    foreach (var dependency in await item.dependencies)
                         parentNode.AddDependency(GetNode(dependency));
                 }
             }
@@ -201,7 +202,7 @@ namespace MadsKristensen.EditorExtensions.Helpers
 
                 parentNode.ClearDependencies();
 
-                foreach (var dependency in dependencies)
+                foreach (var dependency in await dependencies)
                 {
                     var childNode = GetNode(dependency, out created);
                     parentNode.AddDependency(childNode);
@@ -361,10 +362,12 @@ namespace MadsKristensen.EditorExtensions.Helpers
         }
 
         // This is triggered by the derived class' ContentType-specific [Export(typeof(IFileSaveListener))]
-        public void FileSaved(IContentType contentType, string path, bool forceSave, bool minifyInPlace)
+        public Task FileSaved(IContentType contentType, string path, bool forceSave, bool minifyInPlace)
         {
             if (IsEnabled)
                 RescanComplete = Task.Run(() => RescanFileAsync(path)).HandleErrors("parsing " + path + " for dependencies");
+
+            return null;
         }
         #endregion
     }
@@ -381,10 +384,10 @@ namespace MadsKristensen.EditorExtensions.Helpers
             parserFactory = CssParserLocator.FindComponent(ContentType);
         }
 
-        protected override IEnumerable<string> GetDependencyPaths(string fileName)
+        protected async override Task<IEnumerable<string>> GetDependencyPaths(string fileName)
         {
             var sourceUri = new Uri(fileName);
-            var cachedFileContent = File.ReadAllText(fileName);
+            var cachedFileContent = await FileHelpers.ReadAllTextRetry(fileName);
 
             return new CssItemAggregator<string> { (ImportDirective id) => GetImportPaths(sourceUri, id) }
                             .Crawl(parserFactory.CreateParser().Parse(cachedFileContent, false));

--- a/EditorExtensions/Shared/Margins/CssTextViewMargin.cs
+++ b/EditorExtensions/Shared/Margins/CssTextViewMargin.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -53,7 +52,7 @@ namespace MadsKristensen.EditorExtensions.Margin
                 Header = "Go To Definition",
                 InputGestureText = "F12",
                 Command = new GoToDefinitionCommand(GoToDefinitionCommandHandler, () =>
-                { return _compilerResult != null && _compilerResult.SourceMap.IsCompleted; })
+                { return _compilerResult != null && _compilerResult.SourceMap.IsCompleted && SourceTextView.Properties.ContainsProperty("CssSourceMap"); })
             };
 
             menu.Items.Add(_goToMenuItem);
@@ -101,7 +100,7 @@ namespace MadsKristensen.EditorExtensions.Margin
             if (sourceInfo.SourceFilePath != Document.FilePath)
                 FileHelpers.OpenFileInPreviewTab(sourceInfo.SourceFilePath);
 
-            string content = File.ReadAllText(sourceInfo.SourceFilePath);
+            string content = await FileHelpers.ReadAllTextRetry(sourceInfo.SourceFilePath);
 
             var finalPositionInSource = content.NthIndexOfCharInString('\n', (int)sourceInfo.OriginalLine) + sourceInfo.OriginalColumn;
 

--- a/EditorExtensions/SweetJs/Compilers/SweetJsCompiler.cs
+++ b/EditorExtensions/SweetJs/Compilers/SweetJsCompiler.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using MadsKristensen.EditorExtensions.Settings;
 using Microsoft.VisualStudio.Utilities;
 
@@ -33,11 +34,11 @@ namespace MadsKristensen.EditorExtensions.SweetJs
             return args.ToString();
         }
 
-        protected override string PostProcessResult(string resultSource, string sourceFileName, string targetFileName)
+        protected async override Task<string> PostProcessResult(string resultSource, string sourceFileName, string targetFileName)
         {
             Logger.Log(ServiceName + ": " + Path.GetFileName(sourceFileName) + " compiled.");
 
-            return resultSource;
+            return await Task.FromResult(resultSource);
         }
     }
 }

--- a/EditorExtensions/TypeScript/Compilers/TypeScriptCompilationNotifier.cs
+++ b/EditorExtensions/TypeScript/Compilers/TypeScriptCompilationNotifier.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using EnvDTE;
 using MadsKristensen.EditorExtensions.Commands;
 using MadsKristensen.EditorExtensions.Compilers;
@@ -122,7 +123,7 @@ namespace MadsKristensen.EditorExtensions.TypeScript
                 CompilationReady(this, e);
         }
 
-        private void FileTouched(object sender, FileSystemEventArgs e)
+        private async void FileTouched(object sender, FileSystemEventArgs e)
         {
             // The check for _isReady is in place to deal with the issue where
             // FileSystemWatcher fires twice per file change.
@@ -134,39 +135,39 @@ namespace MadsKristensen.EditorExtensions.TypeScript
 
             if (File.Exists(TargetFilePath))
             {
-                RaiseReady();
+                RaiseReady().DontWait("reading " + TargetFilePath + "file");
 
                 foreach (var listener in _listeners)
-                    listener.FileSaved(ContentTypeManager.GetContentType("JavaScript"), TargetFilePath, false, false);
+                    await listener.FileSaved(ContentTypeManager.GetContentType("JavaScript"), TargetFilePath, false, false);
             }
             _isReady = false;
         }
 
-        public void RequestCompilationResult(bool cached)
+        public async void RequestCompilationResult(bool cached)
         {
             if (File.Exists(TargetFilePath))
-                RaiseReady();
+                RaiseReady().DontWait("reading " + TargetFilePath + "file");
             else
                 OnCompilationReady(new CompilerResultEventArgs(
-                         CompilerResultFactory.GenerateResult(
-                              sourceFileName: SourceFilePath,
-                              targetFileName: null,
-                              isSuccess: true,   // HACK: Set IsSuccess to true to force margin to display result
-                              result: "// Not compiled to disk yet",
-                              errors: null
-                          )));
+                         await CompilerResultFactory.GenerateResult(
+                                  sourceFileName: SourceFilePath,
+                                  targetFileName: null,
+                                  isSuccess: true,   // HACK: Set IsSuccess to true to force margin to display result
+                                  result: "// Not compiled to disk yet",
+                                  errors: null
+                              )));
         }
 
-        private void RaiseReady()
+        private async Task RaiseReady()
         {
             OnCompilationReady(new CompilerResultEventArgs(
-                     CompilerResultFactory.GenerateResult(
-                          sourceFileName: SourceFilePath,
-                          targetFileName: TargetFilePath,
-                          isSuccess: true,
-                          result: File.ReadAllText(TargetFilePath),
-                          errors: null
-                      )));
+                     await CompilerResultFactory.GenerateResult(
+                              sourceFileName: SourceFilePath,
+                              targetFileName: TargetFilePath,
+                              isSuccess: true,
+                              result: await FileHelpers.ReadAllTextRetry(TargetFilePath),
+                              errors: null
+                          )));
         }
     }
 }

--- a/EditorExtensions/WebEssentials2013.csproj
+++ b/EditorExtensions/WebEssentials2013.csproj
@@ -119,6 +119,9 @@
     <Reference Include="Microsoft.JSON.Editor">
       <HintPath>$(DevEnvDir)\Extensions\Microsoft\Web Tools\Languages\Microsoft.JSON.Editor.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Practices.TransientFaultHandling.Core">
+      <HintPath>..\packages\TransientFaultHandling.Core.5.1.1209.1\lib\NET4\Microsoft.Practices.TransientFaultHandling.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.JSLS" />
     <Reference Include="Microsoft.VisualStudio.Language.StandardClassification" />
     <Reference Include="Microsoft.CSS.Core, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -342,6 +345,9 @@
     <Compile Include="Markdown\Classify\MarkdownParser.cs" />
     <Compile Include="SCSS\SmartTags\ScssExtractVariableSmartTagProvider.cs" />
     <Compile Include="Shared\Completion\ColorSwatchIntellisenseProvider.cs" />
+    <Compile Include="Shared\ExtensionMethods\TaskExtensions\PolicyFactory.cs" />
+    <Compile Include="Shared\ExtensionMethods\TaskExtensions\Strategies\FileTransientErrorDetectionStrategy.cs" />
+    <Compile Include="Shared\ExtensionMethods\TaskExtensions\TaskExtensions.cs" />
     <Compile Include="Shared\Helpers\SourceMapNode.cs" />
     <Compile Include="Shared\Helpers\CssSourceMap.cs" />
     <Compile Include="Shared\Helpers\Base64Vlq.cs" />

--- a/EditorExtensions/packages.config
+++ b/EditorExtensions/packages.config
@@ -4,5 +4,6 @@
   <package id="ConfOxide" version="1.3.0.0" targetFramework="net451" />
   <package id="MarkdownSharp" version="1.13.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net451" />
+  <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net451" />
   <package id="WebMarkupMin.Core" version="0.8.13" targetFramework="net45" />
 </packages>

--- a/WebEssentials2013.sln
+++ b/WebEssentials2013.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+VisualStudioVersion = 12.0.30324.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{140A15DE-0F66-4377-BB52-BC24C7FC46E9}"
 	ProjectSection(SolutionItems) = preProject
@@ -44,5 +44,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		EnterpriseLibraryConfigurationToolBinariesPath = packages\TransientFaultHandling.Core.5.1.1209.1\lib\NET4
 	EndGlobalSection
 EndGlobal

--- a/WebEssentialsTests/Tests/NodeExecutors/SweetJsCompilationTests.cs
+++ b/WebEssentialsTests/Tests/NodeExecutors/SweetJsCompilationTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
-using FluentAssertions;
+using MadsKristensen.EditorExtensions;
 using MadsKristensen.EditorExtensions.Settings;
 using MadsKristensen.EditorExtensions.SweetJs;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -32,11 +32,11 @@ namespace WebEssentialsTests.Tests.NodeExecutors
                 if (!File.Exists(compiledFile))
                     continue;
 
-                var expectedLines = File.ReadLines(compiledFile);
+                var expectedLines = await FileHelpers.ReadAllTextRetry(compiledFile);
 
                 var compiledCode = await new SweetJsCompiler().CompileToStringAsync(sweetFileName);
 
-                compiledCode.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None).Should().Equal(expectedLines);
+                compiledCode.Replace("\r\n", "\n").Equals(expectedLines, StringComparison.CurrentCulture);
             }
         }
     }

--- a/WebEssentialsTests/Tests/NodeModules/NodeModuleImportedTests.cs
+++ b/WebEssentialsTests/Tests/NodeModules/NodeModuleImportedTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Threading.Tasks;
 using MadsKristensen.EditorExtensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -14,101 +15,101 @@ namespace WebEssentialsTests
         private static readonly string SourceDirectory = Path.Combine(BaseDirectory, @"fixtures\fake-node-source");
 
         #region Helper Methods
-        private static string Require(string modulePath)
+        private async static Task<string> Require(string modulePath)
         {
-            return NodeModuleService.ResolveModule(SourceDirectory, modulePath);
+            return await NodeModuleService.ResolveModule(SourceDirectory, modulePath);
         }
 
-        private static void AssertRequire(string modulePath, string expectedFile, string message = null)
+        private async static Task AssertRequire(string modulePath, string expectedFile, string message = null)
         {
             Assert.AreEqual(
                 expectedFile == null ? null : Path.GetFullPath(Path.Combine(TargetFixturesDir, expectedFile)),
-                Require(modulePath),
+                await Require(modulePath),
                 message ?? ("require('" + modulePath + "') failed")
             );
         }
         #endregion
 
         [TestMethod]
-        public void BasicResolveTest()
+        public async Task BasicResolveTest()
         {
             // Custom Tests:
-            AssertRequire("../module-resolution/packages/main/package", "packages/main/package.json");
+            await AssertRequire("../module-resolution/packages/main/package", "packages/main/package.json");
 
             // Imported from Node.js:
-            AssertRequire("../module-resolution/a.js", "a.js");
+            await AssertRequire("../module-resolution/a.js", "a.js");
 
             // require a file without any extensions
-            AssertRequire("../module-resolution/foo", "foo");
-            AssertRequire("../module-resolution/a", "a.js");
-            AssertRequire("../module-resolution/b/c", "b/c.js");
-            AssertRequire("../module-resolution/b/d", "b/d.js");
+            await AssertRequire("../module-resolution/foo", "foo");
+            await AssertRequire("../module-resolution/a", "a.js");
+            await AssertRequire("../module-resolution/b/c", "b/c.js");
+            await AssertRequire("../module-resolution/b/d", "b/d.js");
 
             // Test loading relative paths from different files (adapted from require()s spread across files)
-            Assert.AreEqual(Require("./module-resolution/b/c.js"), NodeModuleService.ResolveModule("./b/c", Require("../module-resolution/a")));
-            Assert.AreEqual(Require("./module-resolution/b/d.js"), NodeModuleService.ResolveModule("./d", Require("../module-resolution/b/c")));
-            Assert.AreEqual(Require("./module-resolution/b/package/index.js"), NodeModuleService.ResolveModule("./package", Require("../module-resolution/b/c")));
+            Assert.AreEqual(await Require("./module-resolution/b/c.js"), await NodeModuleService.ResolveModule("./b/c", await Require("../module-resolution/a")));
+            Assert.AreEqual(await Require("./module-resolution/b/d.js"), await NodeModuleService.ResolveModule("./d", await Require("../module-resolution/b/c")));
+            Assert.AreEqual(await Require("./module-resolution/b/package/index.js"), await NodeModuleService.ResolveModule("./package", await Require("../module-resolution/b/c")));
 
             // Absolute
             // I see no reason to support absolute paths.
             //Assert.AreEqual(Require("../module-resolution/b/d"), Require(Path.Combine(SourceDirectory, "../module-resolution/b/d")));
 
             // Adapted from test index.js modules ids and relative loading
-            Assert.AreNotEqual(NodeModuleService.ResolveModule(Path.GetDirectoryName(Require("../module-resolution/nested-index/two")), "./hello"),
-                               NodeModuleService.ResolveModule(Path.GetDirectoryName(Require("../module-resolution/nested-index/one")), "./hello")
+            Assert.AreNotEqual(NodeModuleService.ResolveModule(Path.GetDirectoryName(await Require("../module-resolution/nested-index/two")), "./hello"),
+                               NodeModuleService.ResolveModule(Path.GetDirectoryName(await Require("../module-resolution/nested-index/one")), "./hello")
                               );
 
-            AssertRequire("../module-resolution/empty", null);
+            await AssertRequire("../module-resolution/empty", null);
         }
 
         [TestMethod]
-        public void TrailingSlashTest()
+        public async Task TrailingSlashTest()
         {
             // Adapted from test index.js in a folder with a trailing slash
-            string three = Require("../module-resolution/nested-index/three"),
-                   threeFolder = Require("../module-resolution/nested-index/three/"),
-                   threeIndex = Require("../module-resolution/nested-index/three/index.js");
+            string three = await Require("../module-resolution/nested-index/three"),
+                   threeFolder = await Require("../module-resolution/nested-index/three/"),
+                   threeIndex = await Require("../module-resolution/nested-index/three/index.js");
             Assert.AreEqual(threeFolder, threeIndex);
             Assert.AreNotEqual(threeFolder, three);
         }
 
         [TestMethod]
-        public void PackageJsonTest()
+        public async Task PackageJsonTest()
         {
             // Adapted from test package.json require() loading
-            AssertRequire("../module-resolution/packages/main", "packages/main/package-main-module.js", "Failed loading package");
-            AssertRequire("../module-resolution/packages/main-index", "packages/main-index/package-main-module/index.js", "Failed loading package with index.js in main subdir");
+            await AssertRequire("../module-resolution/packages/main", "packages/main/package-main-module.js", "Failed loading package");
+            await AssertRequire("../module-resolution/packages/main-index", "packages/main-index/package-main-module/index.js", "Failed loading package with index.js in main subdir");
         }
 
         [TestMethod]
-        public void ParentDirCyclesTest()
+        public async Task ParentDirCyclesTest()
         {
             // Adapted from test cycles containing a .. path
-            Assert.AreEqual(Require("./module-resolution/cycles/folder/foo.js"), NodeModuleService.ResolveModule("./folder/foo", Require("../module-resolution/cycles/root")));
-            Assert.AreEqual(Require("./module-resolution/cycles/root.js"), NodeModuleService.ResolveModule("./../root", Require("../module-resolution/cycles/folder/foo")));
+            Assert.AreEqual(await Require("./module-resolution/cycles/folder/foo.js"), await NodeModuleService.ResolveModule("./folder/foo", await Require("../module-resolution/cycles/root")));
+            Assert.AreEqual(await Require("./module-resolution/cycles/root.js"), await NodeModuleService.ResolveModule("./../root", await Require("../module-resolution/cycles/folder/foo")));
         }
 
         [TestMethod]
-        public void NodeModulesTest()
+        public async Task NodeModulesTest()
         {
             var basePath = Path.Combine(TargetFixturesDir, "node_modules");
 
             // Custom Tests:
-            Assert.AreEqual(Require("../module-resolution/node_modules/baz/otherFile.js"), NodeModuleService.ResolveModule(basePath, "baz/otherFile"));
+            Assert.AreEqual(await Require("../module-resolution/node_modules/baz/otherFile.js"), await NodeModuleService.ResolveModule(basePath, "baz/otherFile"));
 
             // Imported from Node.js:
 
             // Adapted from test node_modules folders
 
-            Assert.AreEqual(Require("../module-resolution/node_modules/baz/index.js"), NodeModuleService.ResolveModule(basePath, "baz"));
-            Assert.AreEqual(NodeModuleService.ResolveModule(basePath, "./baz/index.js"), NodeModuleService.ResolveModule(basePath, "baz"));
+            Assert.AreEqual(await Require("../module-resolution/node_modules/baz/index.js"), await NodeModuleService.ResolveModule(basePath, "baz"));
+            Assert.AreEqual(await NodeModuleService.ResolveModule(basePath, "./baz/index.js"), await NodeModuleService.ResolveModule(basePath, "baz"));
 
             basePath += @"\baz";
-            Assert.AreEqual(NodeModuleService.ResolveModule(basePath, "../bar.js"), NodeModuleService.ResolveModule(basePath, "bar"));
-            Assert.AreEqual(Require("../module-resolution/node_modules/bar.js"), NodeModuleService.ResolveModule(basePath, "bar"));
+            Assert.AreEqual(await NodeModuleService.ResolveModule(basePath, "../bar.js"), await NodeModuleService.ResolveModule(basePath, "bar"));
+            Assert.AreEqual(await Require("../module-resolution/node_modules/bar.js"), await NodeModuleService.ResolveModule(basePath, "bar"));
 
-            Assert.AreEqual(NodeModuleService.ResolveModule(basePath, "./node_modules/asdf.js"), NodeModuleService.ResolveModule(basePath, "asdf"));
-            Assert.AreEqual(Require("../module-resolution/node_modules/baz/node_modules/asdf"), NodeModuleService.ResolveModule(basePath, "asdf"));
+            Assert.AreEqual(await NodeModuleService.ResolveModule(basePath, "./node_modules/asdf.js"), await NodeModuleService.ResolveModule(basePath, "asdf"));
+            Assert.AreEqual(await Require("../module-resolution/node_modules/baz/node_modules/asdf"), await NodeModuleService.ResolveModule(basePath, "asdf"));
         }
     }
 }


### PR DESCRIPTION
- Uses [Enterprise Library](http://msdn.microsoft.com/library/cc467894.aspx) for "retry policy".
- Routes all File IO read/write calls to helper.
- Fixes CoffeeScript, SCSS and LESS compilation-<br>   related issues.
- Fixes TypeScript crashing issues.
- Fixes tests.
- Other minor fixes.
- Targeting #871, #887, #890, #897, #868 & #904.

More details can be found at #871.

Special thanks to @SLaks for all the tips & tricks :+1: :smile: 
