### PR TITLE
Margin: Null checks for CSS pre-processors (#910)

### DIFF
--- a/EditorExtensions/Misc/MenuItems/BundleFiles.cs
+++ b/EditorExtensions/Misc/MenuItems/BundleFiles.cs
@@ -63,10 +63,11 @@ namespace MadsKristensen.EditorExtensions
 
         public async static Threading.Task BindAllBundlesAssets(string path)
         {
-            foreach (var file in Directory.EnumerateFiles(Path.GetDirectoryName(path), "*.bundle", SearchOption.AllDirectories))
-            {
-                await ObserveBundleFileObjects(file);
-            }
+            if (path != null)
+                foreach (var file in Directory.EnumerateFiles(Path.GetDirectoryName(path), "*.bundle", SearchOption.AllDirectories))
+                {
+                    await ObserveBundleFileObjects(file);
+                }
         }
 
         private async static Threading.Task ObserveBundleFileObjects(string file)

--- a/EditorExtensions/Shared/Margins/CssTextViewMargin.cs
+++ b/EditorExtensions/Shared/Margins/CssTextViewMargin.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
@@ -25,7 +26,7 @@ namespace MadsKristensen.EditorExtensions.Margin
             {
                 _compilerResult = result as CssCompilerResult;
 
-                UpdateResults();
+                UpdateResults().DontWait("updating TextView property");
                 SetText(result.Result);
             }
             else
@@ -34,12 +35,15 @@ namespace MadsKristensen.EditorExtensions.Margin
                       + "\r\n\r\n*/");
         }
 
-        private async void UpdateResults()
+        private async Task UpdateResults()
         {
-            if (SourceTextView.Properties.ContainsProperty("CssSourceMap"))
-                SourceTextView.Properties.RemoveProperty("CssSourceMap");
+            if (_compilerResult != null)
+            {
+                if (SourceTextView.Properties.ContainsProperty("CssSourceMap"))
+                    SourceTextView.Properties.RemoveProperty("CssSourceMap");
 
-            SourceTextView.Properties.AddProperty("CssSourceMap", await _compilerResult.SourceMap);
+                SourceTextView.Properties.AddProperty("CssSourceMap", await _compilerResult.SourceMap.ConfigureAwait(false));
+            }
         }
 
         protected override void AddSpecialItems(ItemsControl menu)


### PR DESCRIPTION
Fixes #910.
