### PR TITLE
TransientIO: Finishing task is mandatory (#976)

### DIFF
--- a/EditorExtensions/CoffeeScript/Compilers/CoffeeScriptCompiler.cs
+++ b/EditorExtensions/CoffeeScript/Compilers/CoffeeScriptCompiler.cs
@@ -23,7 +23,7 @@ namespace MadsKristensen.EditorExtensions.CoffeeScript
         public override bool RequireMatchingFileName { get { return true; } }
         protected override Regex ErrorParsingPattern { get { return _errorParsingPattern; } }
 
-        protected override string GetArguments(string sourceFileName, string targetFileName)
+        protected override string GetArguments(string sourceFileName, string targetFileName, string mapFileName)
         {
             var args = new StringBuilder();
 

--- a/EditorExtensions/CoffeeScript/Linters/CoffeeLintCompiler.cs
+++ b/EditorExtensions/CoffeeScript/Linters/CoffeeLintCompiler.cs
@@ -21,7 +21,7 @@ namespace MadsKristensen.EditorExtensions.CoffeeScript
             get { return ParseErrorsWithXml; }
         }
 
-        protected override string GetArguments(string sourceFileName, string targetFileName)
+        protected override string GetArguments(string sourceFileName, string targetFileName, string mapFileName)
         {
             GetOrCreateGlobalSettings(ConfigFileName); // Ensure that default settings exist
 

--- a/EditorExtensions/IcedCoffeeScript/Compilers/IcedCoffeeScriptCompiler.cs
+++ b/EditorExtensions/IcedCoffeeScript/Compilers/IcedCoffeeScriptCompiler.cs
@@ -14,9 +14,9 @@ namespace MadsKristensen.EditorExtensions.IcedCoffeeScript
         public override string ServiceName { get { return "IcedCoffeeScript"; } }
         protected override string CompilerPath { get { return _compilerPath; } }
 
-        protected override string GetArguments(string sourceFileName, string targetFileName)
+        protected override string GetArguments(string sourceFileName, string targetFileName, string mapFileName)
         {
-            return "--runtime inline " + base.GetArguments(sourceFileName, targetFileName);
+            return "--runtime inline " + base.GetArguments(sourceFileName, targetFileName, mapFileName);
         }
     }
 }

--- a/EditorExtensions/JavaScript/Linters/JsCodeStyleCompiler.cs
+++ b/EditorExtensions/JavaScript/Linters/JsCodeStyleCompiler.cs
@@ -15,7 +15,7 @@ namespace MadsKristensen.EditorExtensions.JavaScript
         public override string ServiceName { get { return "JSCS"; } }
         protected override string CompilerPath { get { return _compilerPath; } }
 
-        protected override string GetArguments(string sourceFileName, string targetFileName)
+        protected override string GetArguments(string sourceFileName, string targetFileName, string mapFileName)
         {
             GetOrCreateGlobalSettings(ConfigFileName); // Ensure that default settings exist
 

--- a/EditorExtensions/JavaScript/Linters/JsHintCompiler.cs
+++ b/EditorExtensions/JavaScript/Linters/JsHintCompiler.cs
@@ -49,7 +49,7 @@ namespace MadsKristensen.EditorExtensions.JavaScript
             return globalFile;
         }
 
-        protected override string GetArguments(string sourceFileName, string targetFileName)
+        protected override string GetArguments(string sourceFileName, string targetFileName, string mapFileName)
         {
             GetOrCreateGlobalSettings(ConfigFileName); // Ensure that default settings exist
 

--- a/EditorExtensions/LESS/Compilers/LessCompiler.cs
+++ b/EditorExtensions/LESS/Compilers/LessCompiler.cs
@@ -20,15 +20,12 @@ namespace MadsKristensen.EditorExtensions.Less
         protected override Regex ErrorParsingPattern { get { return _errorParsingPattern; } }
         public override bool GenerateSourceMap { get { return WESettings.Instance.Less.GenerateSourceMaps; } }
 
-        protected override string GetArguments(string sourceFileName, string targetFileName)
+        protected override string GetArguments(string sourceFileName, string targetFileName, string mapFileName)
         {
-            MapFileName = targetFileName + ".map";
-            MapFileName = GenerateSourceMap ? MapFileName : Path.Combine(Path.GetTempPath(), Path.GetFileName(MapFileName));
-
-            string mapDirectory = Path.GetDirectoryName(MapFileName);
+            string mapDirectory = Path.GetDirectoryName(mapFileName);
 
             return string.Format(CultureInfo.CurrentCulture, "--no-color --relative-urls --source-map-basepath=\"{0}\" --source-map=\"{1}\" \"{2}\" \"{3}\"",
-                                 mapDirectory, MapFileName, sourceFileName, targetFileName);
+                                 mapDirectory, mapFileName, sourceFileName, targetFileName);
         }
     }
 }

--- a/EditorExtensions/SCSS/Compilers/ScssCompiler.cs
+++ b/EditorExtensions/SCSS/Compilers/ScssCompiler.cs
@@ -22,12 +22,9 @@ namespace MadsKristensen.EditorExtensions.Scss
         protected override Regex ErrorParsingPattern { get { return _errorParsingPattern; } }
         public override bool GenerateSourceMap { get { return WESettings.Instance.Scss.GenerateSourceMaps; } }
 
-        protected override string GetArguments(string sourceFileName, string targetFileName)
+        protected override string GetArguments(string sourceFileName, string targetFileName, string mapFileName)
         {
-            MapFileName = targetFileName + ".map";
-            MapFileName = GenerateSourceMap ? MapFileName : Path.Combine(Path.GetTempPath(), Path.GetFileName(MapFileName));
-
-            return string.Format(CultureInfo.CurrentCulture, "--source-map \"{0}\" --output-style=expanded \"{1}\" --output \"{2}\"", MapFileName, sourceFileName, targetFileName);
+            return string.Format(CultureInfo.CurrentCulture, "--source-map \"{0}\" --output-style=expanded \"{1}\" --output \"{2}\"", mapFileName, sourceFileName, targetFileName);
         }
 
         //https://github.com/hcatlin/libsass/issues/242

--- a/EditorExtensions/Shared/Compilers/CssCompilerBase.cs
+++ b/EditorExtensions/Shared/Compilers/CssCompilerBase.cs
@@ -65,6 +65,13 @@ namespace MadsKristensen.EditorExtensions
             return UpdateSourceLinkInCssComment(content, FileHelpers.RelativePath(compiledFileName, mapFileName));
         }
 
+        protected override string GetMapFileName(string sourceFileName, string targetFileName)
+        {
+            var mapFileName = targetFileName + ".map";
+
+            return GenerateSourceMap ? mapFileName : Path.Combine(Path.GetTempPath(), Path.GetFileName(mapFileName));
+        }
+
         // Overridden to work around SASS bug
         // TODO: Remove when https://github.com/hcatlin/libsass/issues/242 is fixed
         protected async virtual Task<string> ReadMapFile(string sourceMapFileName) { return await FileHelpers.ReadAllTextRetry(sourceMapFileName); }

--- a/EditorExtensions/SweetJs/Compilers/SweetJsCompiler.cs
+++ b/EditorExtensions/SweetJs/Compilers/SweetJsCompiler.cs
@@ -23,7 +23,7 @@ namespace MadsKristensen.EditorExtensions.SweetJs
         public override bool RequireMatchingFileName { get { return false; } }
         protected override Regex ErrorParsingPattern { get { return _errorParsingPattern; } }
 
-        protected override string GetArguments(string sourceFileName, string targetFileName)
+        protected override string GetArguments(string sourceFileName, string targetFileName, string mapFileName)
         {
             var args = new StringBuilder();
 

--- a/EditorExtensions/TypeScript/Linters/TsLintCompiler.cs
+++ b/EditorExtensions/TypeScript/Linters/TsLintCompiler.cs
@@ -17,7 +17,7 @@ namespace MadsKristensen.EditorExtensions.TypeScript
         public override string ServiceName { get { return "TsLint"; } }
         protected override string CompilerPath { get { return _compilerPath; } }
 
-        protected override string GetArguments(string sourceFileName, string targetFileName)
+        protected override string GetArguments(string sourceFileName, string targetFileName, string mapFileName)
         {
             GetOrCreateGlobalSettings(ConfigFileName); // Ensure that default settings exist
 


### PR DESCRIPTION
Fixes #976.

Keep trying or throw:

Prone to `StackOverFlowException` is some very rare
scenario (if there is a long transaction going on
with the file).

Secondly, fixes the compiler issue where
map filename is the property of base executor
instead of a local variable.
