### PR TITLE
CoffeeScript: Add map file to hierarchy (#825)

### DIFF
--- a/EditorExtensions/CoffeeScript/Compilers/CoffeeScriptCompiler.cs
+++ b/EditorExtensions/CoffeeScript/Compilers/CoffeeScriptCompiler.cs
@@ -15,6 +15,7 @@ namespace MadsKristensen.EditorExtensions.CoffeeScript
     {
         private static readonly string _compilerPath = Path.Combine(WebEssentialsResourceDirectory, @"nodejs\tools\node_modules\coffee-script\bin\coffee");
         private static readonly Regex _errorParsingPattern = new Regex(@"(?<fileName>.*):(?<line>.\d*):(?<column>.\d*): error: (?<message>.*\n.*)", RegexOptions.Multiline);
+        private static readonly Regex _sourceMapInJs = new Regex(@"\/\/\\*#([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*", RegexOptions.Multiline);
 
         public override string TargetExtension { get { return ".js"; } }
         public override bool GenerateSourceMap { get { return WESettings.Instance.CoffeeScript.GenerateSourceMaps; } }
@@ -54,7 +55,20 @@ namespace MadsKristensen.EditorExtensions.CoffeeScript
         {
             Logger.Log(ServiceName + ": " + Path.GetFileName(sourceFileName) + " compiled.");
 
+            if (GenerateSourceMap)
+            {
+                File.Move(Path.ChangeExtension(targetFileName, ".map"), mapFileName);
+                resultSource = UpdateSourceLinkInJsComment(resultSource, FileHelpers.RelativePath(targetFileName, mapFileName));
+            }
+
             return await Task.FromResult(resultSource);
+        }
+
+        private static string UpdateSourceLinkInJsComment(string content, string sourceMapRelativePath)
+        {
+            return _sourceMapInJs.Replace(content,
+                   string.Format(CultureInfo.InvariantCulture,
+                   "//# sourceMappingURL={0}", sourceMapRelativePath));
         }
     }
 }

--- a/EditorExtensions/Shared/Compilers/CssCompilerBase.cs
+++ b/EditorExtensions/Shared/Compilers/CssCompilerBase.cs
@@ -93,7 +93,8 @@ namespace MadsKristensen.EditorExtensions
         private static string UpdateSourceLinkInCssComment(string content, string sourceMapRelativePath)
         {   // Fix sourceMappingURL comment in CSS file with network accessible path.
             return _sourceMapInCss.Replace(content,
-                string.Format(CultureInfo.InvariantCulture, "/*# sourceMappingURL={0} */", sourceMapRelativePath));
+                   string.Format(CultureInfo.InvariantCulture,
+                   "/*# sourceMappingURL={0} */", sourceMapRelativePath));
         }
     }
 }

--- a/EditorExtensions/registry.pkgdef
+++ b/EditorExtensions/registry.pkgdef
@@ -57,26 +57,12 @@
 [$RootKey$\Projects\{E24C65DC-7377-472b-9ABA-BC803B73C61A}\RelatedFiles\.config\.release.config]
 [$RootKey$\Projects\{E24C65DC-7377-472b-9ABA-BC803B73C61A}\RelatedFiles\.config\.debug.config]
 
-// Compiled LESS files
-[$RootKey$\Projects\{E24C65DC-7377-472b-9ABA-BC803B73C61A}\RelatedFiles\.less]
-"RelationType"=dword:00000001
-
-[$RootKey$\Projects\{E24C65DC-7377-472b-9ABA-BC803B73C61A}\RelatedFiles\.less\.css]
-[$RootKey$\Projects\{E24C65DC-7377-472b-9ABA-BC803B73C61A}\RelatedFiles\.less\.min.css]
-
 // Minified CSS files
 [$RootKey$\Projects\{E24C65DC-7377-472b-9ABA-BC803B73C61A}\RelatedFiles\.css]
 "RelationType"=dword:00000001
 
 [$RootKey$\Projects\{E24C65DC-7377-472b-9ABA-BC803B73C61A}\RelatedFiles\.css\.min.css]
 [$RootKey$\Projects\{E24C65DC-7377-472b-9ABA-BC803B73C61A}\RelatedFiles\.css\.css.map]
-
-// Compiled CoffeeScript files
-[$RootKey$\Projects\{E24C65DC-7377-472b-9ABA-BC803B73C61A}\RelatedFiles\.coffee]
-"RelationType"=dword:00000001
-
-//[$RootKey$\Projects\{E24C65DC-7377-472b-9ABA-BC803B73C61A}\RelatedFiles\.coffee\.js]
-//[$RootKey$\Projects\{E24C65DC-7377-472b-9ABA-BC803B73C61A}\RelatedFiles\.coffee\.min.js]
 
 // Minified HTML files
 [$RootKey$\Projects\{E24C65DC-7377-472b-9ABA-BC803B73C61A}\RelatedFiles\.html]


### PR DESCRIPTION
- Fixes #825.
- Change file name.
- Update SourceMapUrl.
- Temporary fix for jashkenas/coffee-script#3297.
