### PR TITLE
Sprite: Name collision bug

### DIFF
--- a/EditorExtensions/Images/MenuItems/SpriteImage.cs
+++ b/EditorExtensions/Images/MenuItems/SpriteImage.cs
@@ -118,7 +118,9 @@ namespace MadsKristensen.EditorExtensions.Images
         {
             _dte.StatusBar.Text = "Generating sprite...";
 
+            //Default file name is the sprite name with specified file extension.
             string imageFile = Path.ChangeExtension(sprite.FileName, sprite.FileExtension);
+
             IEnumerable<SpriteFragment> fragments = await SpriteGenerator.MakeImage(sprite, imageFile, UpdateSpriteAsync);
 
             if (!hasUpdated)
@@ -164,7 +166,20 @@ namespace MadsKristensen.EditorExtensions.Images
                 fileName = dialog.FileName;
             }
 
-            return true;
+            //Check for colliding file names
+            string collidedFile = FileHelpers.GetFileCollisions(Path.ChangeExtension(fileName, Path.GetExtension(_files.First())), ".css", ".scss", ".less", ".map");
+            if (collidedFile == null)
+            {
+                return true;
+            }
+
+            if (MessageBox.Show("The following existing file conflicts with a file that would be generated:\r\n'" + collidedFile + "'.\r\n\r\nWould you like to retry with a different name or cancel?", "File name issue", MessageBoxButtons.RetryCancel, MessageBoxIcon.Exclamation) == DialogResult.Retry)
+            {
+                return GetFileName(out fileName);
+            }
+
+            _dte.StatusBar.Text = "Sprite generation canceled.";
+            return false;
         }
     }
 }

--- a/EditorExtensions/Misc/MenuItems/BundleFiles.cs
+++ b/EditorExtensions/Misc/MenuItems/BundleFiles.cs
@@ -87,10 +87,23 @@ namespace MadsKristensen.EditorExtensions
                 fileName = dialog.FileName;
 
                 if (!fileName.EndsWith(extension + ".bundle", StringComparison.OrdinalIgnoreCase))
-                    fileName = Path.Combine(Path.GetDirectoryName(fileName), Path.GetFileNameWithoutExtension(fileName) + extension + ".bundle");
+                    fileName = Path.Combine(Path.GetDirectoryName(fileName), Path.ChangeExtension(Path.GetFileNameWithoutExtension(fileName), extension) + ".bundle");
             }
 
-            return true;
+            //Check for colliding file names (remove bundle from name before passing in).
+            string collidedFile = FileHelpers.GetFileCollisions(Path.Combine(Path.GetDirectoryName(fileName), Path.GetFileNameWithoutExtension(fileName)));
+            if (collidedFile == null)
+            {
+                return true;
+            }
+
+            if (MessageBox.Show("The following existing file conflicts with a file that would be generated:\r\n'" + collidedFile + "'.\r\n\r\nWould you like to retry with a different name or cancel?", "File name issue", MessageBoxButtons.RetryCancel, MessageBoxIcon.Exclamation) == DialogResult.Retry)
+            {
+                return GetFileName(out fileName, extension);
+            }
+
+            _dte.StatusBar.Text = "Bundle generation canceled.";
+            return false;
         }
 
         public static async Task UpdateAllBundlesAsync(bool isBuild = false)

--- a/EditorExtensions/Shared/Helpers/FileHelpers.cs
+++ b/EditorExtensions/Shared/Helpers/FileHelpers.cs
@@ -408,5 +408,18 @@ namespace MadsKristensen.EditorExtensions
 
             return Path.GetFileNameWithoutExtension(fileNameWithoutPath).Substring(0, fileNameWithoutPath.IndexOf('.'));
         }
+
+        /// <summary>
+        /// Gets the file name collisions.
+        /// </summary>
+        /// <param name="fileName">Name of the file to check.</param>
+        /// <param name="extensions">The extensions to append to the file name to also check.</param>
+        /// <returns>The colliding file name if there is one, else <see langword="null"/>.</returns>
+        public static string GetFileCollisions(string fileName, params string[] extensions)
+        {
+            return File.Exists(fileName)
+                 ? fileName
+                 : extensions.Select(extension => fileName + extension).FirstOrDefault(File.Exists);
+        }
     }
 }


### PR DESCRIPTION
If the sprite name is the same name as any of the files in the sprite, then the sprite creation will fail.

This fix checks for this and adds "_sprite" to the file name if there is a collision.
