### PR TITLE
CoffeeScript: Deletes existing map file

### DIFF
--- a/EditorExtensions/CoffeeScript/Compilers/CoffeeScriptCompiler.cs
+++ b/EditorExtensions/CoffeeScript/Compilers/CoffeeScriptCompiler.cs
@@ -57,7 +57,11 @@ namespace MadsKristensen.EditorExtensions.CoffeeScript
 
             if (GenerateSourceMap)
             {
+                if (File.Exists(mapFileName))
+                    File.Delete(mapFileName);
+
                 File.Move(Path.ChangeExtension(targetFileName, ".map"), mapFileName);
+
                 resultSource = UpdateSourceLinkInJsComment(resultSource, FileHelpers.RelativePath(targetFileName, mapFileName));
             }
 


### PR DESCRIPTION
Rescues from throwing IOException: "The destination file already exists."
