### PR TITLE
Markdown: Include CSS files on generated HTML

### DIFF
--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -607,6 +607,18 @@ namespace MadsKristensen.EditorExtensions.Settings
         [Description("Don't save separate unminified compiler output. This option has no effect when Minify On Save is disabled for HTML.")]
         [DefaultValue(false)]
         public bool MinifyInPlace { get; set; }
+
+        [Category("Compilation")]
+        [DisplayName("Include CSS link into HTML")]
+        [Description("When true, the generated HTML contains link to global and specific CSS files, if presents.")]
+        [DefaultValue(true)]
+        public bool IncludeStylesInHtml { get; set; }
+
+        [Category("Compilation")]
+        [DisplayName("Global CSS file for HTML file")]
+        [Description("The global CSS file is included on the generated HTML file when present.")]
+        [DefaultValue("_md.css")]
+        public string DefaultMainCSSFileToUse { get; set; }
     }
 
     public interface IBundleSettings


### PR DESCRIPTION
Create a complete HTML file from the Markdown file with link to a global and specific CSS file if they are presents.

Based on #679 , the default file name for the global CSS file is <code>_md.css</code>. This parameter can be modified in the settings. The specific CSS file is <code>related_markdown_file_name.md.css</code>. 

Here an example, for 2 Markdown files. <code>Chapter 1</code> will include both CSS files and <code>Chapter 2</code> will include only <code>_md.css</code>.

![image](https://cloud.githubusercontent.com/assets/1680372/2953075/10ffbcc6-da4d-11e3-9e20-fa974b7e6478.png)
