### PR TITLE
Compiler: Test MinifyInPlace for source-map

### DIFF
--- a/EditorExtensions/CoffeeScript/Compilers/CoffeeScriptCompiler.cs
+++ b/EditorExtensions/CoffeeScript/Compilers/CoffeeScriptCompiler.cs
@@ -18,7 +18,7 @@ namespace MadsKristensen.EditorExtensions.CoffeeScript
         private static readonly Regex _sourceMapInJs = new Regex(@"\/\/\\*#([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*", RegexOptions.Multiline);
 
         public override string TargetExtension { get { return ".js"; } }
-        public override bool GenerateSourceMap { get { return WESettings.Instance.CoffeeScript.GenerateSourceMaps; } }
+        public override bool GenerateSourceMap { get { return WESettings.Instance.CoffeeScript.GenerateSourceMaps && !WESettings.Instance.CoffeeScript.MinifyInPlace; } }
         public override string ServiceName { get { return "CoffeeScript"; } }
         protected override string CompilerPath { get { return _compilerPath; } }
         public override bool RequireMatchingFileName { get { return true; } }
@@ -55,12 +55,19 @@ namespace MadsKristensen.EditorExtensions.CoffeeScript
         {
             Logger.Log(ServiceName + ": " + Path.GetFileName(sourceFileName) + " compiled.");
 
+            string realTargetFileName = Path.Combine(Path.GetDirectoryName(targetFileName), FileHelpers.GetFileNameWithoutExtension(targetFileName) + ".js");
+
+            if (WESettings.Instance.CoffeeScript.MinifyInPlace)
+            {
+                File.Delete(realTargetFileName); // Because CoffeeScript compiler doesn't take custom file name as parameter.
+            }
+
             if (GenerateSourceMap)
             {
                 if (File.Exists(mapFileName))
                     File.Delete(mapFileName);
 
-                File.Move(Path.ChangeExtension(targetFileName, ".map"), mapFileName);
+                File.Move(Path.ChangeExtension(realTargetFileName, ".map"), mapFileName);
 
                 resultSource = UpdateSourceLinkInJsComment(resultSource, FileHelpers.RelativePath(targetFileName, mapFileName));
             }

--- a/EditorExtensions/EditorExtensionsPackage.cs
+++ b/EditorExtensions/EditorExtensionsPackage.cs
@@ -134,7 +134,7 @@ namespace MadsKristensen.EditorExtensions
             IconRegistration.RegisterIcons();
 
             // Hook up event handlers
-            Dispatcher.CurrentDispatcher.BeginInvoke(new Action(() =>
+            await Dispatcher.CurrentDispatcher.BeginInvoke(new Action(() =>
             {
                 DTE.Events.BuildEvents.OnBuildDone += BuildEvents_OnBuildDone;
                 DTE.Events.SolutionEvents.Opened += delegate { SettingsStore.Load(); ShowTopMenu(); };
@@ -148,6 +148,7 @@ namespace MadsKristensen.EditorExtensions
             if (_dte.Solution.SolutionBuild.LastBuildInfo != 0)
             {
                 string text = _dte.StatusBar.Text; // respect localization of "Build failed"
+
                 Dispatcher.CurrentDispatcher.BeginInvoke(new Action(() =>
                 {
                     _dte.StatusBar.Text = text;

--- a/EditorExtensions/LESS/Compilers/LessCompiler.cs
+++ b/EditorExtensions/LESS/Compilers/LessCompiler.cs
@@ -18,7 +18,7 @@ namespace MadsKristensen.EditorExtensions.Less
         public override string ServiceName { get { return "LESS"; } }
         protected override string CompilerPath { get { return _compilerPath; } }
         protected override Regex ErrorParsingPattern { get { return _errorParsingPattern; } }
-        public override bool GenerateSourceMap { get { return WESettings.Instance.Less.GenerateSourceMaps; } }
+        public override bool GenerateSourceMap { get { return WESettings.Instance.Less.GenerateSourceMaps && !WESettings.Instance.Less.MinifyInPlace; } }
 
         protected override string GetArguments(string sourceFileName, string targetFileName, string mapFileName)
         {

--- a/EditorExtensions/Misc/Minification/IFileMinifier.cs
+++ b/EditorExtensions/Misc/Minification/IFileMinifier.cs
@@ -19,6 +19,10 @@ namespace MadsKristensen.EditorExtensions.Optimization.Minification
         ///<returns>True if the minified file has changed from the old version on disk.</returns>
         Task<bool> MinifyFile(string sourcePath, string targetPath);
 
+        ///<summary>Minifies an existing file, creating or overwriting the target.</summary>
+        ///<returns>True if the minified file has changed from the old version on disk.</returns>
+        Task<bool> MinifyFile(string sourcePath, string targetPath, bool compilerNeedsSourceMap);
+
         ///<summary>Minifies a string in-memory.</summary>
         string MinifyString(string source);
 
@@ -46,6 +50,12 @@ namespace MadsKristensen.EditorExtensions.Optimization.Minification
 
             return false;
         }
+
+        public async virtual Task<bool> MinifyFile(string sourcePath, string targetPath, bool compilerNeedsSourceMap)
+        {
+            return await MinifyFile(sourcePath, targetPath);
+        }
+
         public abstract string MinifyString(string source);
     }
 
@@ -121,6 +131,14 @@ namespace MadsKristensen.EditorExtensions.Optimization.Minification
         public async override Task<bool> MinifyFile(string sourcePath, string targetPath)
         {
             if (GenerateSourceMap)
+                return await MinifyFileWithSourceMap(sourcePath, targetPath);
+            else
+                return await base.MinifyFile(sourcePath, targetPath);
+        }
+
+        public async override Task<bool> MinifyFile(string sourcePath, string targetPath, bool compilerNeedsSourceMap)
+        {
+            if (GenerateSourceMap && compilerNeedsSourceMap)
                 return await MinifyFileWithSourceMap(sourcePath, targetPath);
             else
                 return await base.MinifyFile(sourcePath, targetPath);

--- a/EditorExtensions/Misc/Minification/MinificationSaveListener.cs
+++ b/EditorExtensions/Misc/Minification/MinificationSaveListener.cs
@@ -25,7 +25,7 @@ namespace MadsKristensen.EditorExtensions.Optimization.Minification
                 return;
 
             if (minifyInPlace)
-                await MinifyFile(contentType, path, path, settings);
+                await MinifyFile(contentType, path, path, settings, !minifyInPlace);
             else
                 await ReMinify(contentType, path, forceSave, settings);
         }
@@ -68,10 +68,10 @@ namespace MadsKristensen.EditorExtensions.Optimization.Minification
                 ProjectHelpers.AddFileToProject(minPath, minPath + ".gzip");
         }
 
-        private async static Task MinifyFile(IContentType contentType, string sourcePath, string minPath, IMinifierSettings settings)
+        private async static Task MinifyFile(IContentType contentType, string sourcePath, string minPath, IMinifierSettings settings, bool compilerNeedsSourceMap = true)
         {
             IFileMinifier minifier = Mef.GetImport<IFileMinifier>(contentType);
-            bool changed = await minifier.MinifyFile(sourcePath, minPath);
+            bool changed = await minifier.MinifyFile(sourcePath, minPath, compilerNeedsSourceMap);
 
             if (settings.GzipMinifiedFiles && (changed || !File.Exists(minPath + ".gzip")))
                 FileHelpers.GzipFile(minPath);

--- a/EditorExtensions/SCSS/Compilers/ScssCompiler.cs
+++ b/EditorExtensions/SCSS/Compilers/ScssCompiler.cs
@@ -20,7 +20,7 @@ namespace MadsKristensen.EditorExtensions.Scss
         public override string TargetExtension { get { return ".css"; } }
         protected override string CompilerPath { get { return _compilerPath; } }
         protected override Regex ErrorParsingPattern { get { return _errorParsingPattern; } }
-        public override bool GenerateSourceMap { get { return WESettings.Instance.Scss.GenerateSourceMaps; } }
+        public override bool GenerateSourceMap { get { return WESettings.Instance.Scss.GenerateSourceMaps && !WESettings.Instance.Scss.MinifyInPlace; } }
 
         protected override string GetArguments(string sourceFileName, string targetFileName, string mapFileName)
         {

--- a/EditorExtensions/SweetJs/Compilers/SweetJsCompiler.cs
+++ b/EditorExtensions/SweetJs/Compilers/SweetJsCompiler.cs
@@ -17,7 +17,7 @@ namespace MadsKristensen.EditorExtensions.SweetJs
         private static readonly Regex _errorParsingPattern = new Regex(@"(?<fileName>.*):(?<line>.\d*):(?<column>.\d*): error: (?<message>.*\n.*)", RegexOptions.Multiline);
 
         public override string TargetExtension { get { return ".js"; } }
-        public override bool GenerateSourceMap { get { return WESettings.Instance.SweetJs.GenerateSourceMaps; } }
+        public override bool GenerateSourceMap { get { return WESettings.Instance.SweetJs.GenerateSourceMaps && !WESettings.Instance.SweetJs.MinifyInPlace; } }
         public override string ServiceName { get { return SweetJsContentTypeDefinition.SweetJsContentType; } }
         protected override string CompilerPath { get { return _compilerPath; } }
         public override bool RequireMatchingFileName { get { return false; } }


### PR DESCRIPTION
Fixes #1070

<h4>Story:</h4>


In VS compiler settings, MinifyInPlace is false
by default. If it is set to true and the target's
GenerateSourceMap setting is also true, the
compiler and its minifying listeners should skip
generating the source-map file (for min file).

In WE's world, mappings in .min.map corresponds
to the immediate source file; that is the
unobtrusive version of the same and _not_ the
pre-processed script (LESS/SCSS/CoffeeScript/SJS)

Also, the only context resolver for pre-processed
script to the source-map is the compiler itself.
Since some compilers don't offer minified output
with source-map directly, it would be disparity
between behaviors, if we go that route. This
would also be rendered as disparity because of
the reasons mentioned in previous paragraph:
(what is .min.map in Web Essentials' jargon).

Therefore, this PR prevents the compiler and
minifier to avoid generating source-map, if
MinifyInPlace is enabled. This will also avoid
the confusions like #1070.
