### PR TITLE
Bundling: Fix for new bundle

### DIFF
--- a/EditorExtensions/Images/MenuItems/SpriteImage.cs
+++ b/EditorExtensions/Images/MenuItems/SpriteImage.cs
@@ -120,6 +120,9 @@ namespace MadsKristensen.EditorExtensions.Images
         {
             _dte.StatusBar.Text = "Generating sprite...";
 
+            if (!hasUpdated)
+                ProjectHelpers.AddFileToActiveProject(sprite.FileName);
+
             //Default file name is the sprite name with specified file extension.
             string imageFile = Path.ChangeExtension(sprite.FileName, sprite.FileExtension);
 
@@ -127,7 +130,6 @@ namespace MadsKristensen.EditorExtensions.Images
 
             if (!hasUpdated)
             {
-                ProjectHelpers.AddFileToActiveProject(sprite.FileName);
                 ProjectHelpers.AddFileToProject(sprite.FileName, imageFile);
                 EditorExtensionsPackage.DTE.ItemOperations.OpenFile(sprite.FileName);
             }

--- a/EditorExtensions/Misc/MenuItems/BundleFiles.cs
+++ b/EditorExtensions/Misc/MenuItems/BundleFiles.cs
@@ -199,12 +199,14 @@ namespace MadsKristensen.EditorExtensions
         {
             _dte.StatusBar.Text = "Generating bundle...";
 
+            if (!hasUpdated)
+                ProjectHelpers.AddFileToActiveProject(bundle.FileName);
+            
             string bundleFile = Path.Combine(Path.GetDirectoryName(bundle.FileName), Path.GetFileNameWithoutExtension(bundle.FileName));
             bool hasChanged = await BundleGenerator.MakeBundle(bundle, bundleFile, UpdateBundleAsync);
 
             if (!hasUpdated)
             {
-                ProjectHelpers.AddFileToActiveProject(bundle.FileName);
                 ProjectHelpers.AddFileToProject(bundle.FileName, bundleFile);
                 EditorExtensionsPackage.DTE.ItemOperations.OpenFile(bundle.FileName);
             }


### PR DESCRIPTION
This fixes #1121 : impossible to create a new JS bundle with WE 2.1.3. I checked for #1071 and I think it's still OK but it's a long specific thread so maybe @am11 can take a look.
