### PR TITLE
Foundation: fix validators

### DIFF
--- a/EditorExtensions/HTML/Validation/FoundationClassValidator.cs
+++ b/EditorExtensions/HTML/Validation/FoundationClassValidator.cs
@@ -50,7 +50,9 @@ namespace MadsKristensen.EditorExtensions.Html
             string[] columnSizeClasses = new string[] { "small-", "medium-", "large-" };
 
             var containColumnClass = input.Split(' ').Any(x => columnClasses.Contains(x));
-            var containSizeClass = columnSizeClasses.Any(x => input.Split(' ').Any(y => y.StartsWith(x, StringComparison.Ordinal)));
+            var containSizeClass = columnSizeClasses.Any(x => input.Split(' ')
+                                                    .Where(toExclude => !toExclude.Contains("block-grid"))
+                                                    .Any(y => y.StartsWith(x, StringComparison.Ordinal)));
 
             // If both are there, or both are missing it's OK
             if ((containColumnClass && containSizeClass) || (!containColumnClass && !containSizeClass))

--- a/WebEssentialsTests/Tests/Foundation/FoundationColumnsValidatorTests.cs
+++ b/WebEssentialsTests/Tests/Foundation/FoundationColumnsValidatorTests.cs
@@ -228,6 +228,46 @@ namespace WebEssentialsTests
         }
 
         [TestMethod]
+        public void OkToHaveLessThan12ColumnsIfCenteredClassPresent()
+        {
+            FoundationColumnsValidator validator = new FoundationColumnsValidator();
+
+            var source = @"<div class='row'>
+                               <div class='small-3 small-centered columns'>3 centered</div>
+                           </div>";
+
+            var tree = new HtmlTree(new TextStream(source));
+
+            tree.Build();
+
+            IList<IHtmlValidationError> compiled = validator.ValidateElement(tree.RootNode.Children[0].Children[0]);
+
+            int expected = 0;
+
+            Assert.AreEqual(expected, compiled.Count);
+        }
+
+        [TestMethod]
+        public void OkToHaveLessThan12ColumnsIfCenteredClassPresentEvenOnAnotherSize()
+        {
+            FoundationColumnsValidator validator = new FoundationColumnsValidator();
+
+            var source = @"<div class='row'>
+                               <div class='small-6 large-centered columns'>6 centered</div>
+                           </div>";
+
+            var tree = new HtmlTree(new TextStream(source));
+
+            tree.Build();
+
+            IList<IHtmlValidationError> compiled = validator.ValidateElement(tree.RootNode.Children[0].Children[0]);
+
+            int expected = 0;
+
+            Assert.AreEqual(expected, compiled.Count);
+        }
+
+        [TestMethod]
         public void ErrorMsgIfMoreThanTwelveColumns()
         {
             FoundationColumnsValidator validator = new FoundationColumnsValidator();
@@ -246,8 +286,60 @@ namespace WebEssentialsTests
             int expected = 1;
 
             Assert.AreEqual(expected, compiled.Count);
-            Assert.IsTrue(compiled[0].Message.Contains("must not exceed 12"));
+            Assert.IsTrue(compiled[0].Message.Contains("more than 12 columns"));
             Assert.IsTrue(compiled[0].Message.Contains("medium-"));
+        }
+
+        /// <summary>
+        /// This test is based on an example from the Foundation documentation.
+        /// http://foundation.zurb.com/docs/components/grid.html
+        /// </summary>
+        [TestMethod]
+        public void TwoRowsOnMobileDesign_ValidExampleWithMoreThan12Columns()
+        {
+            FoundationColumnsValidator validator = new FoundationColumnsValidator();
+
+            var source = @"<div class='row'>
+                              <div class='small-6 large-2 columns'>...</div>
+                              <div class='small-6 large-8 columns'>...</div>
+                              <div class='small-12 large-2 columns'>...</div>
+                           </div>";
+
+            var tree = new HtmlTree(new TextStream(source));
+
+            tree.Build();
+
+            IList<IHtmlValidationError> compiled = validator.ValidateElement(tree.RootNode.Children[0].Children[0]);
+
+            int expected = 0;
+
+            Assert.AreEqual(expected, compiled.Count);
+        }
+
+        /// <summary>
+        /// This test is based on an example from the Foundation documentation.
+        /// http://foundation.zurb.com/docs/components/grid.html
+        /// </summary>
+        [TestMethod]
+        public void TwoRowsOnMobileDesign_InvalidExampleWithMoreThan12ColumnsBecauseNotMultipleOfTwelve()
+        {
+            FoundationColumnsValidator validator = new FoundationColumnsValidator();
+
+            var source = @"<div class='row'>
+                              <div class='small-6 large-2 columns'>...</div>
+                              <div class='small-6 large-8 columns'>...</div>
+                              <div class='small-8 large-2 columns'>...</div>
+                           </div>";
+
+            var tree = new HtmlTree(new TextStream(source));
+
+            tree.Build();
+
+            IList<IHtmlValidationError> compiled = validator.ValidateElement(tree.RootNode.Children[0].Children[0]);
+
+            int expected = 1;
+
+            Assert.AreEqual(expected, compiled.Count);
         }
     }
 }

--- a/WebEssentialsTests/Tests/Foundation/FoundationValidationTests.cs
+++ b/WebEssentialsTests/Tests/Foundation/FoundationValidationTests.cs
@@ -52,7 +52,15 @@ namespace WebEssentialsTests
 
                 Assert.IsFalse(result);
             }
+            [TestMethod]
+            public void NoWarningForFoundationBlockGridClass()
+            {
+                var input = @"small-block-grid-3";
 
+                var result = FoundationClassValidator.ColumnPairElementsOk(input);
+
+                Assert.IsTrue(result);
+            }
         }
 
         [TestClass]
@@ -154,6 +162,7 @@ namespace WebEssentialsTests
 
                 Assert.AreEqual(expected, compiled.Count);
             }
+
         }
     }
 }


### PR DESCRIPTION
This fixes all problems discussed on #1122 :
- No warning when the design defines two rows on mobile for a single row.
- No warning when using [size]-centered or [size]-uncentered class
- Doesn't calculate for column size for [size]-block-grid element
