### PR TITLE
SCSS: Possible to change Output Style

### DIFF
--- a/EditorExtensions/SCSS/Compilers/ScssCompiler.cs
+++ b/EditorExtensions/SCSS/Compilers/ScssCompiler.cs
@@ -24,14 +24,17 @@ namespace MadsKristensen.EditorExtensions.Scss
 
         protected override string GetArguments(string sourceFileName, string targetFileName, string mapFileName)
         {
+            string outputStyle = WESettings.Instance.Scss.OutputStyle.ToString();
+
             // Source maps would be generated in "ALL" cases (regardless of the settings).
             // If the option in settings is disabled, we will delete the map file once the
             // B64VLQ values are extracted.
             return string.Format(CultureInfo.CurrentCulture,
-                   "--source-map \"{0}\" --output-style=expanded \"{1}\" --output \"{2}\"",
+                   "--source-map \"{0}\" --output-style={3} \"{1}\" --output \"{2}\"",
                    mapFileName,
                    sourceFileName,
-                   targetFileName);
+                   targetFileName,
+                   outputStyle);
         }
 
         //https://github.com/hcatlin/libsass/issues/242

--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -506,7 +506,26 @@ namespace MadsKristensen.EditorExtensions.Settings
         public bool StrictMath { get; set; }
     }
 
-    public sealed class ScssSettings : ChainableCompilationSettings<ScssSettings> { }
+    public sealed class ScssSettings : ChainableCompilationSettings<ScssSettings>
+    {
+
+        public enum OutputStyles
+        {
+            nested = 0,
+            expanded = 1,
+            compact = 2,
+            compressed = 3
+        }
+
+        // Default value is forces to 'expanded' even if the default value 
+        // for the tool is 'nested' to not change the current behavior of 
+        // WebEssentials that used this value before it has configurable. 
+        [Category("Compilation")]
+        [DisplayName("Output Style")]
+        [Description("CSS output style")]
+        [DefaultValue(1)]
+        public OutputStyles OutputStyle { get; set; }
+    }
 
     public sealed class CoffeeScriptSettings : CompilationSettings<CoffeeScriptSettings>, ILinterSettings
     {


### PR DESCRIPTION
Add an option to change the [output-style](https://github.com/andrew/node-sass#command-line-interface) for the SASS compiler as suggested on #1143
