### PR TITLE
Typescript: Add support for Dictionary in intellisense file generation

### DIFF
--- a/WebEssentialsTests/Tests/IntellisenseGeneration/IntellisenseWriteTypeScriptTests.cs
+++ b/WebEssentialsTests/Tests/IntellisenseGeneration/IntellisenseWriteTypeScriptTests.cs
@@ -11,6 +11,10 @@ namespace WebEssentialsTests.Tests.IntellisenseGeneration
         private readonly IntellisenseType _int32Type = new IntellisenseType { CodeName = "Int32" };
         private readonly IntellisenseType _int32ArrayType = new IntellisenseType { CodeName = "Int32", IsArray = true };
         private readonly IntellisenseType _simpleType = new IntellisenseType { CodeName = "Foo.Simple", ClientSideReferenceName = "server.Simple" };
+        private readonly IntellisenseType _stringDictionary = new IntellisenseType { CodeName = "Dictionary<string, string>", IsDictionary = true };
+        private readonly IntellisenseType _numberDictionary = new IntellisenseType { CodeName = "Dictionary<int, string>", IsDictionary = true };
+        private readonly IntellisenseType _objectDictionary = new IntellisenseType { CodeName = "Dictionary<string, object>", IsDictionary = true };
+        private readonly IntellisenseType _GuidObjectDictionary = new IntellisenseType { CodeName = "Dictionary<Guid, object>", IsDictionary = true };
 
         [TestMethod]
         public void TypeScript_with_on_string_property()
@@ -35,6 +39,7 @@ declare module server {
     }
 }");
         }
+
         [TestMethod]
         public void TypeScript_with_a_string_an_int_and_and_int_arrayproperty()
         {
@@ -64,6 +69,87 @@ declare module server {
         theSimple: server.Simple;
 }
 }");
+        }
+
+        [TestMethod]
+        public void TypeScript_with_a_string_and_simple_dictionary_property()
+        {
+            var result = new StringBuilder();
+
+            var io = new IntellisenseObject(new[]
+            {
+                new IntellisenseProperty(_stringType, "AString"),
+                new IntellisenseProperty(_stringDictionary, "ADictionary")
+            })
+            {
+                FullName = "Foo",
+                Name = "Bar",
+                Namespace = "server"
+            };
+            IntellisenseWriter.WriteTypeScript(new[] { io }, result);
+
+            result.ShouldBeCode(@"
+                declare module server {
+                       interface Bar {
+                        aString: string;
+                        aDictionary: { [index: string]: string };
+                    }
+                }"
+            );
+        }
+
+        [TestMethod]
+        public void TypeScript_with_a_string_and_number_dictionary_property()
+        {
+            var result = new StringBuilder();
+
+            var io = new IntellisenseObject(new[]
+            {
+                new IntellisenseProperty(_stringType, "AString"),
+                new IntellisenseProperty(_numberDictionary, "ADictionary")
+            })
+            {
+                FullName = "Foo",
+                Name = "Bar",
+                Namespace = "server"
+            };
+            IntellisenseWriter.WriteTypeScript(new[] { io }, result);
+
+            result.ShouldBeCode(@"
+                declare module server {
+                       interface Bar {
+                        aString: string;
+                        aDictionary: { [index: number]: string };
+                    }
+                }"
+            );
+        }
+
+        [TestMethod]
+        public void TypeScript_with_a_string_and_object_dictionary_property()
+        {
+            var result = new StringBuilder();
+
+            var io = new IntellisenseObject(new[]
+            {
+                new IntellisenseProperty(_stringType, "AString"),
+                new IntellisenseProperty(_GuidObjectDictionary, "ADictionary")
+            })
+            {
+                FullName = "Foo",
+                Name = "Bar",
+                Namespace = "server"
+            };
+            IntellisenseWriter.WriteTypeScript(new[] { io }, result);
+
+            result.ShouldBeCode(@"
+                declare module server {
+                       interface Bar {
+                        aString: string;
+                        aDictionary: { [index: string]: any };
+                    }
+                }"
+            );
         }
 
     }


### PR DESCRIPTION
Dictionary will be now be generated properly in Typescript as reported in this [old issue](https://github.com/madskristensen/WebEssentials2013/issues/338#issuecomment-31635732)

C#

``` c#
Dictionary<string, int> Foo
```

Was

``` js
Foo: any[];
```

And now is

``` js
Foo: { [index: string]: number; }
```
