### PR TITLE
TSLint: removed catchClause from typedef rule

### DIFF
--- a/EditorExtensions/Resources/settings-defaults/tslint.json
+++ b/EditorExtensions/Resources/settings-defaults/tslint.json
@@ -53,7 +53,6 @@
     "triple-equals": [true, "allow-null-check"],
     "typedef": [true,
         "callSignature",
-        "catchClause",
         "indexSignature",
         "parameter",
         "propertySignature",


### PR DESCRIPTION
According to the TypeScript spec this wasn't supported. Therefore this option is removed from latest tslint.

5.11
 The variable introduced by a ‘catch’ clause of a ‘try’ statement is always of type Any. It is not possible to include a type annotation in a ‘catch’ clause.
