### PR TITLE
Allow for customizing SASS number precision in Web Essentials Options

### DIFF
--- a/EditorExtensions/SCSS/Compilers/ScssCompiler.cs
+++ b/EditorExtensions/SCSS/Compilers/ScssCompiler.cs
@@ -36,7 +36,7 @@ namespace MadsKristensen.EditorExtensions.Scss
                    outputStyle,
                    sourceFileName,
                    targetFileName,
-				   numberPrecision);
+                   numberPrecision);
         }
 
         //https://github.com/hcatlin/libsass/issues/242

--- a/EditorExtensions/Settings/LegacySettings.cs
+++ b/EditorExtensions/Settings/LegacySettings.cs
@@ -41,7 +41,6 @@ namespace MadsKristensen.EditorExtensions.Settings
             target.Scss.CompileOnBuild = GetBoolean("SassCompileOnBuild");
             target.Scss.GenerateSourceMaps = GetBoolean("SassSourceMaps");
             target.Scss.OutputDirectory = GetNonBooleanString("SassCompileToLocation");
-            target.Scss.NumberPrecision = GetInt("SassNumberPrecision");
 
             // TypeScript
             target.TypeScript.ShowPreviewPane = GetBoolean("TypeScriptShowPreviewWindow");


### PR DESCRIPTION
This adds the option to set the number precision for SASS.  the number precision will determine how many digits are output after the decimal place in any number in a Sass file.

![2014-06-20 13_46_12-greenshot](https://cloud.githubusercontent.com/assets/463685/3343755/7cbb8dfe-f8a3-11e3-9b22-d01d5d0cff4a.png)

---
# Use Case:

Compiling [Bootstrap Sass](https://github.com/twbs/bootstrap-sass) requires Sass's number precision to be set to `10` instead of the default of `5`.  Allowing this change will let bootstrap (and other projects) output the values that their authors intended.

**SASS input**

```
.example{ 
    line-height: 1.428571429; 
}
```

**CSS output (with precision set to 5)**

```
.example{ 
    line-height: 1.42857;  /* Boo! Number gets truncated! */
}
```

**CSS output (with precision set to 10)**

```
.example{ 
    line-height: 1.428571429; /* Yay, number is exactly what was written! */
}
```
