### PR TITLE
Bundle: Observe renaming and creation

### DIFF
--- a/EditorExtensions/Images/Sprite/SpriteDocument.cs
+++ b/EditorExtensions/Images/Sprite/SpriteDocument.cs
@@ -82,6 +82,11 @@ namespace MadsKristensen.EditorExtensions.Images
             }
         }
 
+        public async Task<IBundleDocument> LoadFromFile(string fileName)
+        {
+            return await SpriteDocument.FromFile(fileName);
+        }
+
         public static async Task<SpriteDocument> FromFile(string fileName)
         {
             string root = ProjectHelpers.GetProjectFolder(fileName);

--- a/EditorExtensions/Misc/Bundles/BundleDocument.cs
+++ b/EditorExtensions/Misc/Bundles/BundleDocument.cs
@@ -83,6 +83,11 @@ namespace MadsKristensen.EditorExtensions
             }
         }
 
+        public async Task<IBundleDocument> LoadFromFile(string fileName)
+        {
+            return await BundleDocument.FromFile(fileName);
+        }
+
         public static async Task<BundleDocument> FromFile(string fileName)
         {
             var extension = Path.GetExtension(fileName).TrimStart('.').ToLowerInvariant();

--- a/EditorExtensions/Misc/Bundles/IBundleDocument.cs
+++ b/EditorExtensions/Misc/Bundles/IBundleDocument.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace MadsKristensen.EditorExtensions
 {
@@ -6,5 +7,7 @@ namespace MadsKristensen.EditorExtensions
     {
         string FileName { get; }
         IEnumerable<string> BundleAssets { get; }
+
+        Task<IBundleDocument> LoadFromFile(string fileName);
     }
 }

--- a/EditorExtensions/Misc/MenuItems/ProjectSettings.cs
+++ b/EditorExtensions/Misc/MenuItems/ProjectSettings.cs
@@ -51,6 +51,11 @@ namespace MadsKristensen.EditorExtensions
                 Func<string, bool, Task> bundleFunc = new BundleFilesMenu().UpdateBundleAsync;
                 Func<string, bool, Task> spriteFunc = new SpriteImageMenu().UpdateSpriteAsync;
 
+                BundleFileObserver observer = new BundleFileObserver();
+
+                observer.WatchFutureFiles(folder, "*.bundle", async (s) => { await BundleGenerator.WatchFiles(await BundleDocument.FromFile(s), bundleFunc); });
+                observer.WatchFutureFiles(folder, "*.sprite", async (s) => { await SpriteGenerator.WatchFiles(await SpriteDocument.FromFile(s), spriteFunc); });
+
                 foreach (string file in Directory.EnumerateFiles(folder, "*.*", SearchOption.AllDirectories)
                                        .Where(s => s.EndsWith(".bundle") || s.EndsWith(".sprite")))
                 {

--- a/EditorExtensions/Misc/Minification/IFileMinifier.cs
+++ b/EditorExtensions/Misc/Minification/IFileMinifier.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using MadsKristensen.EditorExtensions.Settings;
 using Microsoft.Ajax.Utilities;
 using Microsoft.VisualStudio.Utilities;
-using WebMarkupMin.Core;
 using WebMarkupMin.Core.Minifiers;
 using WebMarkupMin.Core.Settings;
 
@@ -34,7 +33,7 @@ namespace MadsKristensen.EditorExtensions.Optimization.Minification
     {
         public virtual bool GenerateSourceMap { get { return false; } }
 
-        public virtual bool SaveWithBom { get; set; }
+        public virtual bool SaveWithBOM { get; set; }
 
         public async virtual Task<bool> MinifyFile(string sourcePath, string targetPath)
         {
@@ -43,7 +42,7 @@ namespace MadsKristensen.EditorExtensions.Optimization.Minification
             if (result != null && (!File.Exists(targetPath) || result != await FileHelpers.ReadAllTextRetry(targetPath)))
             {
                 ProjectHelpers.CheckOutFileFromSourceControl(targetPath);
-                await FileHelpers.WriteAllTextRetry(targetPath, result, SaveWithBom);
+                await FileHelpers.WriteAllTextRetry(targetPath, result, SaveWithBOM);
                 ProjectHelpers.AddFileToProject(sourcePath, targetPath);
 
                 return true;
@@ -96,8 +95,8 @@ namespace MadsKristensen.EditorExtensions.Optimization.Minification
     [ContentType("CSS")]
     public class CssFileMinifier : InMemoryMinifier
     {
-        public override bool SaveWithBom { get { return true; } }
- 
+        public override bool SaveWithBOM { get { return true; } }
+
         public override string MinifyString(string source)
         {
             Minifier minifier = new Minifier();
@@ -118,7 +117,7 @@ namespace MadsKristensen.EditorExtensions.Optimization.Minification
     {
         public override bool GenerateSourceMap { get { return WESettings.Instance.JavaScript.GenerateSourceMaps; } }
 
-        public override bool SaveWithBom { get { return true; } }
+        public override bool SaveWithBOM { get { return true; } }
 
         static CodeSettings CreateSettings()
         {

--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -205,7 +205,7 @@ namespace MadsKristensen.EditorExtensions.Settings
         [Description("Automatically format HTML source when pressing Enter.")]
         [DefaultValue(true)]
         public bool EnableEnterFormat { get; set; }
-        
+
         [Category("Minification")]
         [DisplayName("Minify files on save")]
         [Description("Update any .min.html file when saving the corresponding .html file. To create a .min.html file, right-click a .html file.")]


### PR DESCRIPTION
**Recipe Creation:**
When a recipe resource is created during the
project lifetime, FileSystemWatcher will start
monitoring the file. It caters the scenario when
we move a bundle file from one directory to
another within the projects under the current
solution.

**Recipe Renaming:**
When a recipe file is renamed, it detaches the
existing FSWs from the recipe file and all its
constituents and reattaches the new ones.

NOTE: this does not respond to the
constituents files' changes, because we do not
want to change the contents of the recipe files
programmatically.
