### PR TITLE
Adding Number Precision option for SCSS

### DIFF
--- a/EditorExtensions/SCSS/Compilers/ScssCompiler.cs
+++ b/EditorExtensions/SCSS/Compilers/ScssCompiler.cs
@@ -25,16 +25,18 @@ namespace MadsKristensen.EditorExtensions.Scss
         protected override string GetArguments(string sourceFileName, string targetFileName, string mapFileName)
         {
             string outputStyle = WESettings.Instance.Scss.OutputStyle.ToString().ToLowerInvariant();
+            string numberPrecision = WESettings.Instance.Scss.NumberPrecision.ToString().ToLowerInvariant();
 
             // Source maps would be generated in "ALL" cases (regardless of the settings).
             // If the option in settings is disabled, we will delete the map file once the
             // B64VLQ values are extracted.
             return string.Format(CultureInfo.CurrentCulture,
-                   "--source-map \"{0}\" --output-style={1} \"{2}\" --output \"{3}\"",
+                   "--source-map \"{0}\" --output-style={1} \"{2}\" --output \"{3}\" --precision={4}",
                    mapFileName,
                    outputStyle,
                    sourceFileName,
-                   targetFileName);
+                   targetFileName,
+                   numberPrecision);
         }
 
         //https://github.com/hcatlin/libsass/issues/242

--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -544,6 +544,12 @@ namespace MadsKristensen.EditorExtensions.Settings
         [Description("CSS output style. See libsass documentation for more details.")]
         [DefaultValue(0)]
         public OutputFormat OutputStyle { get; set; }
+
+        [Category("Compilation")]
+        [DisplayName("Number Precision")]
+        [Description("Used to determine how many digits after the decimal will be allowed.")]
+        [DefaultValue(5)]
+        public int NumberPrecision { get; set; }
     }
 
     public sealed class CoffeeScriptSettings : CompilationSettings<CoffeeScriptSettings>, ILinterSettings


### PR DESCRIPTION
_Note_: This is a revised version of [this pull request](https://github.com/madskristensen/WebEssentials2013/pull/1192). Now it's just a single commit with correct formatting & not updating unneeded files.

---

This adds the option to set the number precision for SASS.  the number precision will determine how many digits are output after the decimal place in any number in a Sass file.

![2014-06-20 13_46_12-greenshot](https://cloud.githubusercontent.com/assets/463685/3343755/7cbb8dfe-f8a3-11e3-9b22-d01d5d0cff4a.png)

---
# Use Case:

Compiling [Bootstrap Sass](https://github.com/twbs/bootstrap-sass) requires Sass's number precision to be set to `10` instead of the default of `5`.  Allowing this change will let bootstrap (and other projects) output the values that their authors intended.

**SASS input**

```
.example{ 
    line-height: 1.428571429; 
}
```

**CSS output (with precision set to 5)**

```
.example{ 
    line-height: 1.42857;  /* Boo! Number gets truncated! */
}
```

**CSS output (with precision set to 10)**

```
.example{ 
    line-height: 1.428571429; /* Yay, number is exactly what was written! */
}
```
