### PR TITLE
NodeExecutorBase: Detect change before writing

### DIFF
--- a/EditorExtensions/CoffeeScript/Compilers/CoffeeScriptCompiler.cs
+++ b/EditorExtensions/CoffeeScript/Compilers/CoffeeScriptCompiler.cs
@@ -11,13 +11,12 @@ namespace MadsKristensen.EditorExtensions.CoffeeScript
 {
     [Export(typeof(NodeExecutorBase))]
     [ContentType("CoffeeScript")]
-    public class CoffeeScriptCompiler : NodeExecutorBase
+    public class CoffeeScriptCompiler : JsCompilerBase
     {
         private static readonly string _compilerPath = Path.Combine(WebEssentialsResourceDirectory, @"nodejs\tools\node_modules\coffee-script\bin\coffee");
         private static readonly Regex _errorParsingPattern = new Regex(@"\A(?<fileName>.*):(?<line>.\d*):(?<column>.\d*): error: (?<fullMessage>(?<message>.*)(\n*.*)*)", RegexOptions.Multiline | RegexOptions.Compiled);
         private static readonly Regex _sourceMapInJs = new Regex(@"\/\/\\*#.*(?i:sourceMappingURL)([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*", RegexOptions.Multiline);
 
-        public override string TargetExtension { get { return ".js"; } }
         public override bool GenerateSourceMap { get { return WESettings.Instance.CoffeeScript.GenerateSourceMaps && !WESettings.Instance.CoffeeScript.MinifyInPlace; } }
         public override string ServiceName { get { return "CoffeeScript"; } }
         protected override string CompilerPath { get { return _compilerPath; } }
@@ -36,19 +35,6 @@ namespace MadsKristensen.EditorExtensions.CoffeeScript
 
             args.AppendFormat(CultureInfo.CurrentCulture, "--output \"{0}\" --compile \"{1}\"", Path.GetDirectoryName(targetFileName), sourceFileName);
             return args.ToString();
-        }
-
-        protected async override Task MoveOutputContentToCorrectTarget(string targetFileName)
-        {
-            if (!targetFileName.EndsWith(".min.js", System.StringComparison.OrdinalIgnoreCase))
-                return;
-
-            var tempName = targetFileName.Replace(".min.js", ".js");
-
-            if (!File.Exists(tempName))
-                return;
-
-            await FileHelpers.WriteAllTextRetry(targetFileName, await FileHelpers.ReadAllTextRetry(tempName));
         }
 
         protected async override Task<string> PostProcessResult(string resultSource, string sourceFileName, string targetFileName, string mapFileName)

--- a/EditorExtensions/LiveScript/Compilers/LiveScriptCompiler.cs
+++ b/EditorExtensions/LiveScript/Compilers/LiveScriptCompiler.cs
@@ -11,12 +11,11 @@ namespace MadsKristensen.EditorExtensions.LiveScript
 {
     [Export(typeof(NodeExecutorBase))]
     [ContentType(LiveScriptContentTypeDefinition.LiveScriptContentType)]
-    public class LiveScriptCompiler : NodeExecutorBase
+    public class LiveScriptCompiler : JsCompilerBase
     {
         private static readonly string _compilerPath = Path.Combine(WebEssentialsResourceDirectory, @"nodejs\tools\node_modules\LiveScript\bin\livescript");
         private static readonly Regex _errorParsingPattern = new Regex(@"Failed at: (?<filename>.*?)Error: (?<message>.*)", RegexOptions.Multiline);
 
-        public override string TargetExtension { get { return ".js"; } }
         public override bool GenerateSourceMap { get { return WESettings.Instance.LiveScript.GenerateSourceMaps; } }
         public override string ServiceName { get { return "LiveScript"; } }
         protected override string CompilerPath { get { return _compilerPath; } }
@@ -32,19 +31,6 @@ namespace MadsKristensen.EditorExtensions.LiveScript
 
             args.AppendFormat(CultureInfo.CurrentCulture, "-o \"{0}\" -c \"{1}\"", Path.GetDirectoryName(targetFileName), sourceFileName);
             return args.ToString();
-        }
-
-        protected async override Task MoveOutputContentToCorrectTarget(string targetFileName)
-        {
-            if (!targetFileName.EndsWith(".min.js", System.StringComparison.OrdinalIgnoreCase))
-                return;
-
-            var tempName = targetFileName.Replace(".min.js", ".js");
-
-            if (!File.Exists(tempName))
-                return;
-
-            await FileHelpers.WriteAllTextRetry(targetFileName, await FileHelpers.ReadAllTextRetry(tempName));
         }
 
         protected async override Task<string> PostProcessResult(string resultSource, string sourceFileName, string targetFileName, string mapFileName)

--- a/EditorExtensions/Shared/Compilers/JsCompilerBase.cs
+++ b/EditorExtensions/Shared/Compilers/JsCompilerBase.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using MadsKristensen.EditorExtensions.Autoprefixer;
+using MadsKristensen.EditorExtensions.Helpers;
+using MadsKristensen.EditorExtensions.Settings;
+using Microsoft.CSS.Core;
+using Newtonsoft.Json.Linq;
+
+namespace MadsKristensen.EditorExtensions
+{
+    ///<summary>A base class for a compiler that rewrites CSS source maps.</summary>
+    public abstract class JsCompilerBase : NodeExecutorBase
+    {
+        public override string TargetExtension { get { return ".js"; } }
+
+        protected async override Task MoveOutputContentToCorrectTarget(string targetFileName)
+        {
+            if (!targetFileName.EndsWith(".min.js", System.StringComparison.OrdinalIgnoreCase))
+                return;
+
+            var tempName = targetFileName.Replace(".min.js", ".js");
+
+            if (!File.Exists(tempName))
+                return;
+
+            string newContent = await FileHelpers.ReadAllTextRetry(tempName);
+
+            if (!File.Exists(targetFileName) || !ReferenceEquals(string.Intern(newContent), string.Intern(await FileHelpers.ReadAllTextRetry(targetFileName))))
+                await FileHelpers.WriteAllTextRetry(targetFileName, newContent);
+        }
+    }
+}

--- a/EditorExtensions/SweetJs/Compilers/SweetJsCompiler.cs
+++ b/EditorExtensions/SweetJs/Compilers/SweetJsCompiler.cs
@@ -11,12 +11,11 @@ namespace MadsKristensen.EditorExtensions.SweetJs
 {
     [Export(typeof(NodeExecutorBase))]
     [ContentType(SweetJsContentTypeDefinition.SweetJsContentType)]
-    public class SweetJsCompiler : NodeExecutorBase
+    public class SweetJsCompiler : JsCompilerBase
     {
         private static readonly string _compilerPath = Path.Combine(WebEssentialsResourceDirectory, @"nodejs\tools\node_modules\sweet.js\bin\sjs");
         private static readonly Regex _errorParsingPattern = new Regex(@"\A(?<fileName>.+):(.*?\n*.*?)*?Line.+(?<line>\d+): (?<fullMessage>(?<message>.*)(\n*.*)*)", RegexOptions.Multiline | RegexOptions.Compiled);
 
-        public override string TargetExtension { get { return ".js"; } }
         public override bool GenerateSourceMap { get { return WESettings.Instance.SweetJs.GenerateSourceMaps && !WESettings.Instance.SweetJs.MinifyInPlace; } }
         public override string ServiceName { get { return SweetJsContentTypeDefinition.SweetJsContentType; } }
         protected override string CompilerPath { get { return _compilerPath; } }

--- a/EditorExtensions/WebEssentials2013.csproj
+++ b/EditorExtensions/WebEssentials2013.csproj
@@ -362,6 +362,7 @@
     <Compile Include="SCSS\Commands\ScssCreationListener.cs" />
     <Compile Include="SCSS\Commands\ScssExtractMixinCommandTarget.cs" />
     <Compile Include="SCSS\Commands\ScssExtractVariableCommandTarget.cs" />
+    <Compile Include="Shared\Compilers\JsCompilerBase.cs" />
     <Compile Include="Shared\Compilers\Result\CompilerResultFactory.cs" />
     <Compile Include="Shared\Compilers\Result\CompilerError.cs" />
     <Compile Include="Shared\Compilers\Result\CssCompilerResult.cs" />


### PR DESCRIPTION
Fixes #1069 and #1224.

Also, adds JsCompileBase for CoffeeScript, LiveScript and SweetJS.
