### PR TITLE
Revert "NodeExecBase: Fixes "delete map file" condition"

### DIFF
--- a/EditorExtensions/Shared/Compilers/NodeExecutorBase.cs
+++ b/EditorExtensions/Shared/Compilers/NodeExecutorBase.cs
@@ -74,7 +74,7 @@ namespace MadsKristensen.EditorExtensions
                 File.Delete(errorOutputFile);
                 File.Delete(tempTarget);
 
-                if (!string.IsNullOrEmpty(mapFileName))
+                if (ManagedSourceMap && !GenerateSourceMap)
                     File.Delete(mapFileName);
             }
         }


### PR DESCRIPTION
@madskristensen, that was a mistake. The current condition is necessary.

@tysonmatanich, can you explain the scenario when it is not deleting the temp map file? When the map file path is set to temp folder, it gets deleted after processing the results.
