### PR TITLE
Feature: WEIgnore (#589)

### DIFF
--- a/EditorExtensions/Images/MenuItems/SpriteImage.cs
+++ b/EditorExtensions/Images/MenuItems/SpriteImage.cs
@@ -128,7 +128,7 @@ namespace MadsKristensen.EditorExtensions.Images
 
             string imageFile = Path.ChangeExtension(sprite.FileName, sprite.FileExtension);
 
-            if (sprite.OutputDirectory != null)
+            if (string.IsNullOrEmpty(sprite.OutputDirectory))
                 imageFile = ProjectHelpers.GetAbsolutePathFromSettings(sprite.OutputDirectory, Path.ChangeExtension(sprite.FileName, sprite.FileExtension));
 
             ProjectHelpers.CreateDirectoryInProject(imageFile);

--- a/EditorExtensions/Misc/Autoprefixer/Autoprefixer.cs
+++ b/EditorExtensions/Misc/Autoprefixer/Autoprefixer.cs
@@ -22,7 +22,7 @@ namespace MadsKristensen.EditorExtensions.Autoprefixer
             }
 
             var autoprefixResult = await new AutoprefixerCompiler().CompileAsync(targetFileName, targetFileName);
-            if (autoprefixResult.IsSuccess)
+            if (autoprefixResult != null && autoprefixResult.IsSuccess)
             {
                 result = autoprefixResult.Result;
 

--- a/EditorExtensions/Misc/MenuItems/BundleFiles.cs
+++ b/EditorExtensions/Misc/MenuItems/BundleFiles.cs
@@ -207,7 +207,7 @@ namespace MadsKristensen.EditorExtensions
 
             string bundleFile = Path.Combine(Path.GetDirectoryName(bundle.FileName), Path.GetFileNameWithoutExtension(bundle.FileName));
 
-            if (bundle.OutputDirectory != null)
+            if (!string.IsNullOrEmpty(bundle.OutputDirectory))
                 bundleFile = ProjectHelpers.GetAbsolutePathFromSettings(bundle.OutputDirectory, Path.Combine(Path.GetDirectoryName(bundle.FileName), Path.GetFileNameWithoutExtension(bundle.FileName)));
 
             ProjectHelpers.CreateDirectoryInProject(bundleFile);

--- a/EditorExtensions/Settings/WEIgnore.cs
+++ b/EditorExtensions/Settings/WEIgnore.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Minimatch;
+
+namespace MadsKristensen.EditorExtensions.Settings
+{
+    public static class WEIgnore
+    {
+        public static bool TestWEIgnore(string sourcePath, string serviceToken, string serviceName)
+        {
+            string ignoreFile = GetIgnoreFile(Path.GetDirectoryName(sourcePath), ".weignore");
+
+            if (string.IsNullOrEmpty(ignoreFile))
+                return false;
+
+            string searchPattern;
+
+            using (StreamReader reader = File.OpenText(ignoreFile))
+            {
+                while ((searchPattern = reader.ReadLine()) != null)
+                {
+                    searchPattern = searchPattern.Trim();
+
+                    if (string.IsNullOrEmpty(searchPattern) || searchPattern[0] == '!') // Negated pattern
+                        continue;
+
+                    int index = searchPattern.LastIndexOf('\t');
+
+                    if (index > 0)
+                    {
+                        string[] subparts = searchPattern.Substring(++index, searchPattern.Length - index).Split(',')
+                                           .Select(p => p.Trim().ToLowerInvariant()).ToArray();
+
+                        if (!(subparts.Contains(serviceToken) || subparts.Contains(serviceName)) &&
+                            (subparts.Contains("!" + serviceToken) || subparts.Contains("!" + serviceName) ||
+                            !subparts.Any(s => s[0] == '!')))
+                            continue;
+
+                        searchPattern = searchPattern.Substring(0, index).Trim('\t');
+                    }
+
+                    Minimatcher miniMatcher = new Minimatcher(searchPattern, new Options { AllowWindowsPaths = true });
+
+                    if (miniMatcher.IsMatch(sourcePath))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string GetIgnoreFile(string startDir, string settingsFileName)
+        {
+            while (!File.Exists(Path.Combine(startDir, settingsFileName)))
+            {
+                startDir = Path.GetDirectoryName(startDir);
+
+                if (String.IsNullOrEmpty(startDir))
+                    break;
+            }
+
+            if (String.IsNullOrEmpty(startDir))
+                startDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+            string fileName = Path.Combine(startDir, settingsFileName);
+
+            if (!File.Exists(fileName))
+                return null;
+
+            return fileName;
+        }
+    }
+}

--- a/EditorExtensions/Shared/Classify/IconRegistration.cs
+++ b/EditorExtensions/Shared/Classify/IconRegistration.cs
@@ -39,7 +39,7 @@ namespace MadsKristensen.EditorExtensions
                 AddIcon(classes, "Git.ico", ".gitignore", ".gitattributes");
 
                 // Generic script
-                AddIcon(classes, "GenericScript.ico", ".appcache", JsHintCompiler.ConfigFileName, ".jshintignore", TsLintCompiler.ConfigFileName, JsCodeStyleCompiler.ConfigFileName, CoffeeLintCompiler.ConfigFileName, ".sjs", ".jsonld", ".bowerrc");
+                AddIcon(classes, "GenericScript.ico", ".appcache", JsHintCompiler.ConfigFileName, ".weignore", ".jshintignore", TsLintCompiler.ConfigFileName, JsCodeStyleCompiler.ConfigFileName, CoffeeLintCompiler.ConfigFileName, ".sjs", ".jsonld", ".bowerrc");
 
                 // Jigsaw
                 AddIcon(classes, "Jigsaw.ico", ".sprite");

--- a/EditorExtensions/Shared/Compilers/CompilerRunner.cs
+++ b/EditorExtensions/Shared/Compilers/CompilerRunner.cs
@@ -146,7 +146,7 @@ namespace MadsKristensen.EditorExtensions.Compilers
         {
             var result = await RunCompilerAsync(sourcePath, targetPath);
 
-            if (result.IsSuccess && !string.IsNullOrEmpty(targetPath))
+            if (result != null && result.IsSuccess && !string.IsNullOrEmpty(targetPath))
             {
                 ProjectHelpers.AddFileToProject(sourcePath, targetPath);
 

--- a/EditorExtensions/Shared/Compilers/EditorCompilerInvoker.cs
+++ b/EditorExtensions/Shared/Compilers/EditorCompilerInvoker.cs
@@ -93,6 +93,10 @@ namespace MadsKristensen.EditorExtensions.Compilers
         private async Task InitiateCompilationAsync(string sourcePath, bool save, bool cached = false)
         {
             var result = await CompilerRunner.CompileAsync(sourcePath, save);
+
+            if (result == null)
+                return;
+
             OnCompilationReady(new CompilerResultEventArgs(result), cached);
         }
     }

--- a/EditorExtensions/Shared/Compilers/NodeExecutorBase.cs
+++ b/EditorExtensions/Shared/Compilers/NodeExecutorBase.cs
@@ -6,6 +6,8 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using MadsKristensen.EditorExtensions.JavaScript;
+using MadsKristensen.EditorExtensions.Settings;
 using Newtonsoft.Json;
 
 namespace MadsKristensen.EditorExtensions
@@ -29,6 +31,12 @@ namespace MadsKristensen.EditorExtensions
 
         public async Task<CompilerResult> CompileAsync(string sourceFileName, string targetFileName)
         {
+            if (WEIgnore.TestWEIgnore(sourceFileName, this is ILintCompiler ? "linter" : "compiler", ServiceName.ToLowerInvariant()))
+            {
+                Logger.Log(String.Format(CultureInfo.CurrentCulture, "{0}: The file {1} is ignored by .weignore. Skipping..", ServiceName, Path.GetFileName(sourceFileName)));
+                return null;
+            }
+
             if (RequireMatchingFileName &&
                 Path.GetFileName(targetFileName) != Path.GetFileNameWithoutExtension(sourceFileName) + TargetExtension &&
                 Path.GetFileName(targetFileName) != Path.GetFileNameWithoutExtension(sourceFileName) + ".min" + TargetExtension)

--- a/EditorExtensions/Shared/Linters/LintReporter.cs
+++ b/EditorExtensions/Shared/Linters/LintReporter.cs
@@ -83,6 +83,9 @@ namespace MadsKristensen.EditorExtensions
 
             WebEssentialsPackage.DTE.StatusBar.Clear();
 
+            if (result == null)
+                return;
+
             // Hack to select result from Error: 
             // See https://github.com/madskristensen/WebEssentials2013/issues/392#issuecomment-31566419
             ReadResult(result.Errors);

--- a/EditorExtensions/WebEssentials2013.csproj
+++ b/EditorExtensions/WebEssentials2013.csproj
@@ -185,6 +185,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(DevEnvDir)\CommonExtensions\Microsoft\Web\Editor\Microsoft.Web.Editor.dll</HintPath>
     </Reference>
+    <Reference Include="Minimatch">
+      <HintPath>..\packages\Minimatch.1.0.0.0\lib\portable-net40+sl50+wp80+win\Minimatch.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -362,6 +365,7 @@
     <Compile Include="SCSS\Commands\ScssCreationListener.cs" />
     <Compile Include="SCSS\Commands\ScssExtractMixinCommandTarget.cs" />
     <Compile Include="SCSS\Commands\ScssExtractVariableCommandTarget.cs" />
+    <Compile Include="Settings\WEIgnore.cs" />
     <Compile Include="Shared\Compilers\JsCompilerBase.cs" />
     <Compile Include="Shared\Compilers\Result\CompilerResultFactory.cs" />
     <Compile Include="Shared\Compilers\Result\CompilerError.cs" />

--- a/EditorExtensions/packages.config
+++ b/EditorExtensions/packages.config
@@ -5,4 +5,5 @@
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net451" />
   <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net451" />
   <package id="WebMarkupMin.Core" version="0.8.21" targetFramework="net451" />
+  <package id="Minimatch" version="1.0.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Fixes #589, #638, #1241 and this [UserVoice ticket](http://webessentials.uservoice.com/forums/140520-general/suggestions/5341144-allow-less-files-to-be-ignored).

---

_The docs should go to http://www.github.com/madskristensen/vswebessentials.com/ which would eventually appear at http://www.vswebessentials.com/._

---
# WEIgnore

WEIgnore, `.weignore`, is a file containing the list of linefeed-separated file-path patterns to prevent compilers and linters used in Web Essentials (WE). As per @nschonni's [kind suggestion](https://github.com/madskristensen/WebEssentials2013/issues/603#issuecomment-34477078) and @SLaks' cool [Minimatch](http://github.com/slaks/minimatch) utility -- a port of Nodejs' minimatch; it supports both Unix-like and Windows-like file paths.

That said, it supports all styles supported by `.jshintignore`.

**Limitations:**

Currently it only targets nodejs pipeline services, meaning TypeScript compilation (_not TSLint_) and Markdown are out. For markdown, we would probably shift to nodejs-based [marked](https://github.com/chjj/marked/) compiler, once [this feature](https://github.com/chjj/marked/issues/382) is implemented.

**Discoverability:**

It works just like `.jscs`,`.jshintrc`, `coffee.json`, `coffeelint.js` and `tslint.json`. For each request, it looks for `.weignore` file in the current directory, then its parent till the drive's root. After that it will look into user's HOME directory (`c:\users\<your-name>`).

**How it works:**

The first config file that is found in the aforementioned chain takes effect. All the file-path patterns inside the `.weignore` file are relative to the source file being processed, _not the `.weignore` file itself_.

**Basic Usage:**
- To ignore file path including the word "style":

``` text
**/**style**
```
- To ignore path with `.min.js` at the end:

``` text
**/**.min.js
```
- To ignore file path including the folder name "slug":

``` text
**\slug\**
```

or:

``` text
**/slug/**
```
- To ignore the absolute path:

``` text
C:\temp\foo.ts
```

Or:

``` text
C:/temp/foo.ts
```

**Intermediate Complexity:**
- To negate the ignore, use `!` before the path:

``` text
!**/**Content
```
- To ignore the file from any kind of compilation (_only_), specify the term "compiler" after the pattern, separated by <kbd>TAB</kbd>:

``` text
**/doodle.less  compiler
```

**Note:** The space between `doodle.less` and `compiler` is a <kbd>TAB</kbd> `\t`. Although TAB is [not the disallowed character](http://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations) in any major file-system, but it's extremely obscure in usage -- hence the best candidate of our separator. If you have files with <kbd>TAB</kbd> anywhere file path, you are out of luck! :(
- To ignore the file from being processed by LESS compiler, use the word `less`:

``` text
**/doodle.less  less
```
- To ignore the file from being processed by Autoprefixer, use the word `autoprefixer`:

``` text
**/bug.scss autoprefixer
```
- To ignore the file from being processed by a linter, use the word `linter`:

``` text
**/*.js linter
```
- You can also specify a linter's name:

``` text
**/random.js    jscs
```
- If there a case which requires specifying multiple service names, use comma-separated list:

``` text
**/doodle.less  less, autoprefixer
```

Here is the list of all the (node-based) compilers and linters currently supported by WE:
- compiler
  - autoprefixer
  - coffeescript
  - icedcoffeescript
  - less
  - livescript
  - scss
  - sweetjs
- linter
  - jscs
  - jshint
  - tslint

The parent list items are referred as "service-categories" and sub-list constitutes "service-names".

**Advanced Usage (going crazy):**

You can have negation for service type and service names as well!

``` text
**/doodle.less  !less, autoprefixer
```

It will only ignore autoprefixer.

But this:

``` text
!**/*.coffee    !coffeescript
```

will _not_ ignore coffeescript compilation, because the negation of pattern will take precedence. We can implement this logic, if its really desired. Meanwhile, it is recommended to keep your logic simplified (see this Wolfarm|Alpha's [logic expression simplifier](http://www.wolframalpha.com/widget/widgetPopup.jsp?p=v&id=4c86f3bbcab249f879058d1825887571&title=Boolean%20Algebra%20Calculator&theme=green)).

**Precedence:**

As describe above, it first skips the negative patterns (those starting with exclamation mark `!`).

Then it looks for service-category or service-name. If none is found, it moves on to test the pattern match.

If there was tab-separated service category/name specified on the line, before matching the pattern, it checks if the caller service needs to be ignored (or that it has `!`) and skips accordingly.

Take it for a spin with v2.2.3+ ........ :car: 
