### PR TITLE
Fix for "rescroll on save" issue for TypeScript preview pane

### DIFF
--- a/EditorExtensions/Shared/Margins/TextViewMargin.cs
+++ b/EditorExtensions/Shared/Margins/TextViewMargin.cs
@@ -92,23 +92,36 @@ namespace MadsKristensen.EditorExtensions.Margin
 
             try
             {
-
-                if (string.IsNullOrEmpty(text))
+                if (PreviewTextHost.HostControl.CheckAccess())
                 {
-                    PreviewTextHost.HostControl.Opacity = 0.3;
-                    return;
+                    updateThePreviewText(text);
                 }
-
-                int position = PreviewTextHost.TextView.TextViewLines.FirstVisibleLine.Extent.Start.Position;
-                PreviewTextHost.TextView.TextBuffer.SetText(text);
-                PreviewTextHost.HostControl.Opacity = 1;
-                PreviewTextHost.TextView.ViewScroller.ScrollViewportVerticallyByLines(ScrollDirection.Down, PreviewTextHost.TextView.TextSnapshot.GetLineNumberFromPosition(position));
-                PreviewTextHost.TextView.ViewScroller.ScrollViewportHorizontallyByPixels(-9999);
+                else
+                {
+                     this.Dispatcher.Invoke((Action)(() => {
+                         updateThePreviewText(text);
+                     }));
+                }
             }
             catch
             {
                 // Threading issues when called from TypeScript
             }
+        }
+
+        private void updateThePreviewText(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                PreviewTextHost.HostControl.Opacity = 0.3;
+                return;
+            }
+
+            int position = PreviewTextHost.TextView.TextViewLines.FirstVisibleLine.Extent.Start.Position;
+            PreviewTextHost.TextView.TextBuffer.SetText(text);
+            PreviewTextHost.HostControl.Opacity = 1;
+            PreviewTextHost.TextView.ViewScroller.ScrollViewportVerticallyByLines(ScrollDirection.Down, PreviewTextHost.TextView.TextSnapshot.GetLineNumberFromPosition(position));
+            PreviewTextHost.TextView.ViewScroller.ScrollViewportHorizontallyByPixels(-9999);
         }
 
         protected override void UpdateMargin(CompilerResult result)


### PR DESCRIPTION
In Web Essentials v2.2.6.1, the TypeScript JS preview pane always scrolls back to the first line when the TypeScript file is saved.  This presents a significant usability issue for TypeScript files taller than one screen since there is no "scroll sync" feature yet.

The root cause appears to have been related to a cross-thread ownership issue, specifically "The calling thread cannot access this object because a different thread owns it."

This pull request fixes the issue by checking the access to the PreviewTextHost.HostControl before attempting to update anything.  If the current thread has access, it updates everything as before.  If the current thread does not have access, it simply uses the Dispatcher to invoke the update.

I tested this for CoffeeScript and LESS and all seemed to work correctly as before.  TypeScript no longer has the "rollback preview pane to line 1" issue with this update - the preview pane remains in its current location.
