### PR TITLE
srv-less: relativeURLs as a parameter to parser

### DIFF
--- a/EditorExtensions/Resources/server/services/srv-less.js
+++ b/EditorExtensions/Resources/server/services/srv-less.js
@@ -25,7 +25,7 @@ var handleLess = function (writer, params) {
         }
 
         try {
-            new (less.Parser)({ filename: params.sourceFileName }).parse(data, function (e, tree) {
+            new (less.Parser)({ filename: params.sourceFileName, relativeUrls: true }).parse(data, function (e, tree) {
                 if (e) {
                     writer.write(JSON.stringify({
                         Success: false,
@@ -49,7 +49,6 @@ var handleLess = function (writer, params) {
                 var mapFileName = params.targetFileName + ".map";
                 var mapDir = path.dirname(mapFileName);
                 var css = tree.toCSS({
-                    relativeUrl: true,
                     paths: [path.dirname(params.sourceFileName)],
                     sourceMap: mapFileName,
                     sourceMapURL: params.sourceMapURL != undefined ? path.basename(mapFileName) : null,


### PR DESCRIPTION
(As opposed to parameter to compiler)
- Fixed #1328 and #1270.
