### PR TITLE
PreBuild: Using LongPath assembly via reflection

### DIFF
--- a/EditorExtensions/packages.config
+++ b/EditorExtensions/packages.config
@@ -4,6 +4,7 @@
   <package id="ConfOxide" version="1.4.0.0" targetFramework="net451" />
   <package id="Minimatch" version="1.1.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
+  <package id="Pri.LongPath" version="1.0.1" targetFramework="net451" />
   <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net451" />
   <package id="WebMarkupMin.Core" version="0.8.21" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
@madskristensen, 

Using [LongPath](https://github.com/peteraritchie/LongPath) with System.Reflection, this fixes the Web Essentials solution building issue from deep nested directory. 

Now we don't need to compile from drive's root! 8-)
