### PR TITLE
src-jshint: Now supports jshint-ignore

### DIFF
--- a/EditorExtensions/Resources/server/services/srv-jshint.js
+++ b/EditorExtensions/Resources/server/services/srv-jshint.js
@@ -48,6 +48,7 @@ var handleJSHint = function (writer, params) {
 
     jshint.run({
         args: [params.sourceFileName],
+        cwd: path.dirname(params.sourceFileName),
         reporter: function (results) { reporter(results, writer, params); }
     });
 };


### PR DESCRIPTION
Based on the fix made in upstream https://github.com/jshint/jshint/commit/0165d5c4ef03c10e7c086c0f8aee9501a1b49d6b, which is available in jshint-v2.5.3.
