### PR TITLE
Fixing VS crash on bundle file deleted (#1401)

### DIFF
--- a/EditorExtensions/Misc/Bundles/BundleGenerator.cs
+++ b/EditorExtensions/Misc/Bundles/BundleGenerator.cs
@@ -33,7 +33,9 @@ namespace MadsKristensen.EditorExtensions
 
             if (bundleChanged)
             {
-                ProjectHelpers.CheckOutFileFromSourceControl(bundleFile);
+                if (!ProjectHelpers.CheckOutFileFromSourceControl(bundleFile))
+                    throw new Exception("There was a problem checking out the file: " + bundleFile);
+                    
                 await FileHelpers.WriteAllTextRetry(bundleFile, combinedContent);
                 Logger.Log("Web Essentials: Updated bundle: " + Path.GetFileName(bundleFile));
             }


### PR DESCRIPTION
This doesn't happen a lot unless you have gated check-ins. If you happen to have locks on dlls, checking-in will revert your changes thus deleting the bundle file you just added.

Changed the BundleFileObserver.Changed and BundleFileObserver.Deleted from `async void` to `void`, that helped the crash stack trace to show in the event log and then fixed the problem.

I also added an exception while bundling if `ProjectHelpers.CheckOutFileFromSourceControl` would return false as it would try to write to a file that has not been checked-out for some reason. (it would retry 500 times and then complete the bundling job in error). This happens to me quite often, the work around is to hit the refresh button in the explorer (seems to sync tfs status or something). This doesn't fix the problem, but at least it won't try 500 times.

(and yes, I did run the code analysis rules and didn't add any more warnings)
