### PR TITLE
Fix NullReferenceException error during build when looking for CompileOnBuild settings.

### DIFF
--- a/EditorExtensions/WebEssentialsPackage.cs
+++ b/EditorExtensions/WebEssentialsPackage.cs
@@ -178,7 +178,7 @@ namespace MadsKristensen.EditorExtensions
             {
                 Parallel.ForEach(
                     Mef.GetSupportedContentTypes<ICompilerRunnerProvider>()
-                       .Where(c => WESettings.Instance.ForContentType<ICompilerInvocationSettings>(c).CompileOnBuild),
+                       .Where(c => { var settings = WESettings.Instance.ForContentType<ICompilerInvocationSettings>(c); return settings != null && settings.CompileOnBuild; }),
                     c => compiler.Value.CompileSolutionAsync(c).DoNotWait("compiling solution-wide " + c.DisplayName)
                 );
             }).DoNotWait("running solution-wide compilers");


### PR DESCRIPTION
Ever since yesterday's nightly, I started getting an exception error in the build output whenever I build my solutions:

An exception was thrown when running solution-wide compilers: System.AggregateException: One or more errors occurred. ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at MadsKristensen.EditorExtensions.WebEssentialsPackage.<>c__DisplayClasse.<InitiateExecutors>b__c(IContentType c)
   at System.Linq.Enumerable.<>c__DisplayClassf`1.<CombinePredicates>b__e(TSource x)
   at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
(and on and on)

Traced it down to InitiateExecutors() in WebEssentialsPackage.cs.  the call to ForContentType() returns null for Css.

Not sure why this suddenly started appearing--none of the code involved seemed to have been changed recently.  I'm assuming it's due to logging changes--that its always been there and the exception just wasn't making it to the build output window.
