### PR TITLE
References: Resolves warning issue

### DIFF
--- a/WebEssentialsTests/WebEssentialsTests.csproj
+++ b/WebEssentialsTests/WebEssentialsTests.csproj
@@ -44,12 +44,10 @@
     <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <SpecificVersion>False</SpecificVersion>
       <EmbedInteropTypes>False</EmbedInteropTypes>
-      <HintPath>$(ProgramFiles)\Common Files\Microsoft Shared\MSEnv\PublicAssemblies\envdte.dll</HintPath>
     </Reference>
     <Reference Include="EnvDTE80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <SpecificVersion>False</SpecificVersion>
       <EmbedInteropTypes>False</EmbedInteropTypes>
-      <HintPath>$(ProgramFiles)\Common Files\Microsoft Shared\MSEnv\PublicAssemblies\envdte80.dll</HintPath>
     </Reference>
     <Reference Include="FluentAssertions">
       <HintPath>..\packages\FluentAssertions.3.0.107\lib\net45\FluentAssertions.dll</HintPath>
@@ -242,7 +240,7 @@
       <Lcid>0</Lcid>
       <WrapperTool>primary</WrapperTool>
       <Isolated>False</Isolated>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
     </COMReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
On building the solution, WebEssentialsTest project throws three warnings:

> Warning 1 A reference was created to embedded interop assembly 'c:\Windows\assembly\GAC\stdole\7.0.3300.0__b03f5f7f11d50a3a\stdole.dll' because of an indirect reference to that assembly created by assembly 'c:\Program Files (x86)\Common Files\Microsoft Shared\MSEnv\PublicAssemblies\envdte.dll'. Consider changing the 'Embed Interop Types' property on either assembly. C:\Users\Adeel\Source\Repos\WebEssentials2013\WebEssentialsTests\CSC WebEssentialsTests
> 
> Warning 2 A reference was created to embedded interop assembly 'c:\Windows\assembly\GAC\stdole\7.0.3300.0__b03f5f7f11d50a3a\stdole.dll' because of an indirect reference to that assembly created by assembly 'c:\Program Files (x86)\Common Files\Microsoft Shared\MSEnv\PublicAssemblies\envdte80.dll'. Consider changing the 'Embed Interop Types' property on either assembly. C:\Users\Adeel\Source\Repos\WebEssentials2013\WebEssentialsTests\CSC WebEssentialsTests
> 
> Warning 3 A reference was created to embedded interop assembly 'c:\Windows\assembly\GAC\stdole\7.0.3300.0__b03f5f7f11d50a3a\stdole.dll' because of an indirect reference to that assembly created by assembly 'c:\Program Files (x86)\Microsoft Visual Studio 12.0\VSSDK\VisualStudioIntegration\Common\Assemblies\v4.0\Microsoft.VisualStudio.Shell.12.0.dll'. Consider changing the 'Embed Interop Types' property on either assembly. C:\Users\Adeel\Source\Repos\WebEssentials2013\WebEssentialsTests\CSC WebEssentialsTests

This PR fixes it.
