### PR TITLE
Markdown: Add support for default CSS file.

### DIFF
--- a/EditorExtensions/Markdown/MenuItems/Markdown.cs
+++ b/EditorExtensions/Markdown/MenuItems/Markdown.cs
@@ -54,7 +54,7 @@ namespace MadsKristensen.EditorExtensions.Markdown
         {
             OleMenuCommand menuCommand = sender as OleMenuCommand;
 
-            menuCommand.Enabled = !File.Exists(MarkdownMargin.GetCustomStylesheetFilePath());
+            menuCommand.Enabled = !MarkdownMargin.HasCustomStylesheet;
         }
 
         private void IsMarkdownFile(object sender, System.EventArgs e)


### PR DESCRIPTION
If a file named WE-Markdown.css exists in the user's local AppData, then
it will be used as a default CSS when displaying Markdown (the default
will not be used if the solution contains its own WE-Markdown.css file).

In order to check this feature, place a CSS file such as
[this one](https://git.epsitec.ch/doc/dev/snippets/2) into
`C:\Users\...\AppData\Local\WE-Markdown.css`.

This is equivalent to pull request #1460 but with SPACEs instead of TABs
for the code formatting.