### PR TITLE
Foundation: Fix bug one column OK

### DIFF
--- a/EditorExtensions/HTML/Validation/FoundationClassValidator.cs
+++ b/EditorExtensions/HTML/Validation/FoundationClassValidator.cs
@@ -55,7 +55,8 @@ namespace MadsKristensen.EditorExtensions.Html
                                                     .Any(y => y.StartsWith(x, StringComparison.Ordinal)));
 
             // If both are there, or both are missing it's OK
-            if ((containColumnClass && containSizeClass) || (!containColumnClass && !containSizeClass))
+            // Ok too if only column without size. The FoundationColumnsValidator will check if it's realy OK (only one column class).
+            if ((containColumnClass && containSizeClass) || (!containColumnClass && !containSizeClass) || (containColumnClass && !containSizeClass))
                 return true;
             else
                 return false;

--- a/EditorExtensions/HTML/Validation/FoundationColumnsValidator.cs
+++ b/EditorExtensions/HTML/Validation/FoundationColumnsValidator.cs
@@ -22,6 +22,7 @@ namespace MadsKristensen.EditorExtensions.Html
         private static string _errorRowMissing = "Foundation: When using \"{0}\", you must also specify the class \"row\" on the parent element.";
         private static string _errorOver12Columns = "Foundation: \"{0}\" - If you define more than 12 columns, the sum should be a multiple of 12. For examples: http://foundation.zurb.com/docs/components/grid.html";
         private static string _errorUnder12Columns = "Foundation: \"{0}\" - When declaring less then 12 columns, the last column need the 'end' class element.";
+        private static string _onlyOneColumnWithoutSizeAllowed = "Foundation: When declaring column without size, only one element with the class 'column' (or 'columns') is allowed for a parent 'row' element.";
 
         public override IList<IHtmlValidationError> ValidateElement(ElementNode element)
         {
@@ -73,6 +74,13 @@ namespace MadsKristensen.EditorExtensions.Html
 
                 if (containCenteredElement)
                     return results;
+            }
+
+            // Ok to not have size class only if there is only one column defined (that will be 100%)
+            if (classList.Count() == 0 && !IsParentDivContainOnlyOneChildColumnElement(element))
+            {
+                var index = element.Attributes.IndexOf(elementClasses);
+                results.AddAttributeError(element, _onlyOneColumnWithoutSizeAllowed, HtmlValidationErrorLocation.AttributeValue, index);
             }
 
             foreach (var columnSize in classList)
@@ -154,6 +162,18 @@ namespace MadsKristensen.EditorExtensions.Html
                 // For the grid system of Foundation, the row class must be on the direct parent element.
                 return true;
             }
+        }
+
+        private static bool IsParentDivContainOnlyOneChildColumnElement(ElementNode element)
+        {
+            var sumOfColumns = element.Parent.Children
+                            .Where(x => x.HasAttribute("class"))
+                            .Where(x => x.GetAttribute("class").Value.Contains("column") || x.GetAttribute("class").Value.Contains("columns")).Count();
+
+            if (sumOfColumns == 1)
+                return true;
+            else
+                return false;
         }
     }
 }

--- a/WebEssentialsTests/Tests/Foundation/FoundationColumnsValidatorTests.cs
+++ b/WebEssentialsTests/Tests/Foundation/FoundationColumnsValidatorTests.cs
@@ -53,6 +53,47 @@ namespace WebEssentialsTests
         }
 
         [TestMethod]
+        public void MinimalistCorrectColumnUsage()
+        {
+            FoundationColumnsValidator validator = new FoundationColumnsValidator();
+
+            var source = @"<div class='row'>
+                              <div class='columns'>12 columns</div>
+                           </div>";
+
+            var tree = new HtmlTree(new TextStream(source));
+
+            tree.Build();
+
+            IList<IHtmlValidationError> compiled = validator.ValidateElement(tree.RootNode.Children[0].Children[0]);
+
+            int expected = 0;
+
+            Assert.AreEqual(expected, compiled.Count);
+        }
+
+        [TestMethod]
+        public void TwoColumnsElementWithoutSize_Error()
+        {
+            FoundationColumnsValidator validator = new FoundationColumnsValidator();
+
+            var source = @"<div class='row'>
+                              <div class='columns'>6 columns</div>
+                              <div class='columns'>6 columns</div>
+                           </div>";
+
+            var tree = new HtmlTree(new TextStream(source));
+
+            tree.Build();
+
+            IList<IHtmlValidationError> compiled = validator.ValidateElement(tree.RootNode.Children[0].Children[0]);
+
+            int expected = 1;
+
+            Assert.AreEqual(expected, compiled.Count);
+        }
+
+        [TestMethod]
         public void CorrectComplexColumnsUsage()
         {
             FoundationColumnsValidator validator = new FoundationColumnsValidator();

--- a/WebEssentialsTests/Tests/Foundation/FoundationValidationTests.cs
+++ b/WebEssentialsTests/Tests/Foundation/FoundationValidationTests.cs
@@ -43,14 +43,17 @@ namespace WebEssentialsTests
                 Assert.IsFalse(result);
             }
 
+            /// <summary>
+            /// It's OK if there is only one 'column'. So let the Columns Validator check for that.
+            /// </summary>
             [TestMethod]
-            public void ColumnClassButMissingSize_Error()
+            public void ColumnClassButMissingSize_OK()
             {
                 var input = @"columns highlight";
 
                 var result = FoundationClassValidator.ColumnPairElementsOk(input);
 
-                Assert.IsFalse(result);
+                Assert.IsTrue(result);
             }
             [TestMethod]
             public void NoWarningForFoundationBlockGridClass()
@@ -106,8 +109,11 @@ namespace WebEssentialsTests
                 System.Console.WriteLine(compiled[0].Message);
             }
 
+            /// <summary>
+            ///  It's OK if there is only one 'column'. So let the Columns Validator check for that.
+            /// </summary>
             [TestMethod]
-            public void MissingSizeClass()
+            public void MissingSizeClass_OkIfOnlyOneColum()
             {
                 FoundationClassValidator validator = new FoundationClassValidator();
 
@@ -119,12 +125,9 @@ namespace WebEssentialsTests
 
                 IList<IHtmlValidationError> compiled = validator.ValidateElement(tree.RootNode.Children[0]);
 
-                int expected = 1;
-                string expectedMessagePart = "When using \"columns\"";
+                int expected = 0;
 
                 Assert.AreEqual(expected, compiled.Count);
-                Assert.IsTrue(compiled[0].Message.Contains(expectedMessagePart));
-                System.Console.WriteLine(compiled[0].Message);
             }
 
             [TestMethod]


### PR DESCRIPTION
It's possible to have a unique column without defining size with Foundation.

This is OK:

```
<div class="row">
    <div class="column"></div>
</div>
```

But the next code block will give this error on each 'column' classes: <code>Foundation: When declaring column without size, only one element with the class 'column' (or 'columns') is allowed for a parent 'row' element.</code>

```
<div class="row">
    <div class="column"></div>
    <div class="column"></div>
</div>
```

This will close #1483 
