### PR TITLE
srv-scss: Changes for downstream v0.9.4

### DIFF
--- a/EditorExtensions/PreBuildTask.cs
+++ b/EditorExtensions/PreBuildTask.cs
@@ -89,11 +89,6 @@ namespace MadsKristensen.EditorExtensions
             if (!FlattenModulesAsync().Result)
                 return false;
 
-            // Patch to disqualify node-sass-middleware
-            string middleware = @"resources\nodejs\tools\node_modules\node-sass-middleware\middleware.js";
-            if (File.Exists(middleware))
-                File.Create(middleware);
-
             return true;
         }
 

--- a/EditorExtensions/Resources/server/services/srv-scss.js
+++ b/EditorExtensions/Resources/server/services/srv-scss.js
@@ -6,19 +6,16 @@ var sass = require("node-sass"),
 
 //#region Handler
 var handleSass = function (writer, params) {
-    params.targetFileName = params.targetFileName.replace(/\\/g, '/');
-    params.sourceFileName = params.sourceFileName.replace(/\\/g, '/');
-    params.mapFileName = params.mapFileName.replace(/\\/g, '/');
-
     sass.render({
         file: params.sourceFileName,
+        outFile: params.targetFileName,
         includePaths: [path.dirname(params.sourceFileName)],
         precision: parseInt(params.precision, 10),
         outputStyle: params.outputStyle,
         sourceMap: params.mapFileName,
+        omitSourceMapUrl: params.sourceMapURL === undefined,
         success: function (css, map) {
             map = JSON.parse(map);
-            map.file = path.basename(params.targetFileName);
 
             if (params.autoprefixer !== undefined) {
                 var autoprefixedOutput = require("./srv-autoprefixer").processAutoprefixer(css, map, params.autoprefixerBrowsers, params.sourceFileName, params.targetFileName);
@@ -42,16 +39,6 @@ var handleSass = function (writer, params) {
 
                 css = autoprefixedOutput.css;
                 map = autoprefixedOutput.map;
-            }
-
-            // SASS doesn't generate source-maps without source-map comments
-            // (unlike LESS and CoffeeScript). So we need to delete the comment
-            // manually if its not present in params.
-            if (params.sourceMapURL === undefined) {
-                var soucemapCommentLineIndex = css.lastIndexOf("\n");
-                if (soucemapCommentLineIndex > 0) {
-                    css = css.substring(0, soucemapCommentLineIndex);
-                }
             }
 
             if (params.rtlcss !== undefined) {

--- a/EditorExtensions/Shared/Helpers/DependencyGraph.cs
+++ b/EditorExtensions/Shared/Helpers/DependencyGraph.cs
@@ -48,7 +48,16 @@ namespace MadsKristensen.EditorExtensions.Helpers
         public async Task<IEnumerable<string>> GetRecursiveDependentsAsync(string fileName)
         {
             HashSet<GraphNode> visited;
-            fileName = Path.GetFullPath(fileName);
+
+            try
+            {
+                fileName = Path.GetFullPath(fileName);
+            }
+            catch (ArgumentException)
+            {
+                return Enumerable.Empty<string>();
+            }
+
             using (await rwLock.ReadLockAsync())
             {
                 GraphNode rootNode;


### PR DESCRIPTION
- Removes node-sass-middleware hack.
- Rescue from ArgumentException.
- Gratitude: @mgreter and @andrew.

---

@madskristensen, should we rollout v2.3.4 nightly? There are tons of improvements made in this newer SASS version.
