### PR TITLE
srv-rtlcss: Prevent from throwing

### DIFF
--- a/EditorExtensions/Resources/server/services/srv-rtlcss.js
+++ b/EditorExtensions/Resources/server/services/srv-rtlcss.js
@@ -11,8 +11,7 @@ var processRtlCSS = function (cssContent, mapContent, autoprefixer, autoprefixer
         mapContent = { prev: mapContent };
     }
 
-    var result;
-
+    var result, css, map;
     try {
         var config = configLoader.load(null, path.dirname(sourceFileName), { options: { minify: false } });
 
@@ -21,8 +20,11 @@ var processRtlCSS = function (cssContent, mapContent, autoprefixer, autoprefixer
             from: sourceFileName,
             to: targetFileName
         });
+
+        css = result.css;
+        map = result.map;
     } catch (e) {
-        // Return same css and map back so compilers can continue.
+        // Return same css and map back so the upstream compilers can continue.
         return {
             Success: false,
             Remarks: "RTLCSS: Exception occured: " + e.message,
@@ -31,8 +33,6 @@ var processRtlCSS = function (cssContent, mapContent, autoprefixer, autoprefixer
         };
     }
 
-    var css = result.css;
-    var map = result.map;
 
     if (autoprefixer !== undefined) {
         var autoprefixedOutput = require("./srv-autoprefixer").processAutoprefixer(css, map, autoprefixerBrowsers, sourceFileName, targetFileName);


### PR DESCRIPTION
The problem is, when both rtlcss and autoprefixer
are enabled, it works fine with SCSS, but throws
with LESS.

When the code is too complicated,
the `result` object seems to have problem with
returning `result.css` member. When the code is
comparatively straight-forward, it throws a
slightly lenient error.

/cc @MohammadYounes
