### PR TITLE
Keep original source/target paths in returned result

### DIFF
--- a/EditorExtensions/Resources/server/services/srv-less.js
+++ b/EditorExtensions/Resources/server/services/srv-less.js
@@ -99,7 +99,7 @@ var handleLess = function (writer, params) {
                     if (!autoprefixedOutput.Success) {
                         writer.write(JSON.stringify({
                             Success: false,
-                            SourceFileName: params.targetFileName,
+                            SourceFileName: params.sourceFileName,
                             TargetFileName: params.targetFileName,
                             MapFileName: params.mapFileName,
                             Remarks: "LESS: " + autoprefixedOutput.Remarks,
@@ -130,9 +130,9 @@ var handleLess = function (writer, params) {
                     if (rtlResult.Success) {
                         writer.write(JSON.stringify({
                             Success: true,
-                            SourceFileName: params.targetFileName,
-                            TargetFileName: rtlTargetFileName,
-                            MapFileName: rtlMapFileName,
+                            SourceFileName: params.sourceFileName,
+                            TargetFileName: params.targetFileName,
+                            MapFileName: params.mapFileName,
                             RtlSourceFileName: params.targetFileName,
                             RtlTargetFileName: rtlTargetFileName,
                             RtlMapFileName: rtlMapFileName,

--- a/EditorExtensions/Resources/server/services/srv-scss.js
+++ b/EditorExtensions/Resources/server/services/srv-scss.js
@@ -23,7 +23,7 @@ var handleSass = function (writer, params) {
                 if (!autoprefixedOutput.Success) {
                     writer.write(JSON.stringify({
                         Success: false,
-                        SourceFileName: params.targetFileName,
+                        SourceFileName: params.sourceFileName,
                         TargetFileName: params.targetFileName,
                         MapFileName: params.mapFileName,
                         Remarks: "SASS: " + autoprefixedOutput.Remarks,
@@ -54,9 +54,9 @@ var handleSass = function (writer, params) {
                 if (rtlResult.Success === true) {
                     writer.write(JSON.stringify({
                         Success: true,
-                        SourceFileName: params.targetFileName,
-                        TargetFileName: rtlTargetFileName,
-                        MapFileName: rtlMapFileName,
+                        SourceFileName: params.sourceFileName,
+                        TargetFileName: params.targetFileName,
+                        MapFileName: params.mapFileName,
                         RtlSourceFileName: params.targetFileName,
                         RtlTargetFileName: rtlTargetFileName,
                         RtlMapFileName: rtlMapFileName,


### PR DESCRIPTION
I made a mistake updating result paths in #1531 this fixes it.
