### PR TITLE
WEIgnore: Log messages are disableable

### DIFF
--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -125,6 +125,12 @@ namespace MadsKristensen.EditorExtensions.Settings
         public bool SvgPreviewPane { get; set; }
 
         bool IMarginSettings.ShowPreviewPane { get { return SvgPreviewPane; } }
+
+        [Category("WE Ignore")]
+        [DisplayName("Show ignore logs")]
+        [Description("Show the log messages in Output Window for each file ignored by .weignore.")]
+        [DefaultValue(true)]
+        public bool ShowWEIgnoreLogs { get; set; }
     }
 
     public sealed class BrowserLinkSettings : SettingsBase<BrowserLinkSettings>

--- a/EditorExtensions/Shared/Compilers/NodeExecutorBase.cs
+++ b/EditorExtensions/Shared/Compilers/NodeExecutorBase.cs
@@ -24,7 +24,10 @@ namespace MadsKristensen.EditorExtensions
 
             if (WEIgnore.TestWEIgnore(sourceFileName, this is ILintCompiler ? "linter" : "compiler", ServiceName.ToLowerInvariant()))
             {
-                Logger.Log(String.Format(CultureInfo.CurrentCulture, "{0}: The file {1} is ignored by .weignore. Skipping..", ServiceName, Path.GetFileName(sourceFileName)));
+                if (WESettings.Instance.General.ShowWEIgnoreLogs)
+                    Logger.Log(String.Format(CultureInfo.CurrentCulture,
+                                            "{0}: The file {1} is ignored by .weignore. Skipping..",
+                                             ServiceName, Path.GetFileName(sourceFileName)));
 
                 if (!Previewing)
                     return await CompilerResultFactory.GenerateResult(sourceFileName, targetFileName, string.Empty, false, string.Empty, string.Empty, Enumerable.Empty<CompilerError>(), true);


### PR DESCRIPTION
Provides a setting for WEIgnore log messages under General.
In some environments, those logs are considered annoying.

The default behavior remains `true`.
