### PR TITLE
JS Src map: ajusted to the Revision 3 Proposal

### DIFF
--- a/EditorExtensions/Misc/Minification/IFileMinifier.cs
+++ b/EditorExtensions/Misc/Minification/IFileMinifier.cs
@@ -201,7 +201,7 @@ namespace MadsKristensen.EditorExtensions.Optimization.Minification
             }
 
             string content = minifier.MinifyJavaScript(await FileHelpers.ReadAllTextRetry(file), settings);
-            content += "\r\n/*\r\n//# sourceMappingURL=" + Path.GetFileName(minFile) + ".map\r\n*/";
+            content += "\r\n//# sourceMappingURL=" + Path.GetFileName(minFile) + ".map";
 
             if (File.Exists(minFile) && content == await FileHelpers.ReadAllTextRetry(minFile))
                 return false;


### PR DESCRIPTION
The [Source Map Revision 3 Proposal](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k) demonstrates the use of source maps like this:

```
 //# sourceMappingURL=<url>
```

and WebEssentials previously generated a link like that, that Google Chrome - at least - doesn't understand:

```
/*
//# sourceMappingURL=<url>
*/
```

This PR will fix #1586 
