### PR TITLE
Bootstrap: Fix alert-link false error

### DIFF
--- a/EditorExtensions/HTML/Validation/BootstrapClassValidator.cs
+++ b/EditorExtensions/HTML/Validation/BootstrapClassValidator.cs
@@ -24,7 +24,8 @@ namespace MadsKristensen.EditorExtensions.Html
         private static string _error = "When using \"{0}\", you must also specify the class \"{1}\".";
         private static Dictionary<string, string[]> _whitelist = new Dictionary<string, string[]>
         {
-            { "btn", new [] { "btn-group", "btn-toolbar" } }
+            { "btn", new [] { "btn-group", "btn-toolbar" } },
+            { "alert", new [] { "alert-link" } }
         };
 
         public override IList<IHtmlValidationError> ValidateElement(ElementNode element)


### PR DESCRIPTION
Added alert-link to the whitelist for alert validations

Fix #1616 

It should be interesting to add a new validation to check that an <code>alert-link</code> have an <code>alert</code> class at the same level or on a parent level but, at least, this modification will remove the false-error for now.
