### PR TITLE
Fix BootstrapLogoCompletion.GetEntires Crash

### DIFF
--- a/EditorExtensions/HTML/Completion/BootstrapLogoCompletion.cs
+++ b/EditorExtensions/HTML/Completion/BootstrapLogoCompletion.cs
@@ -6,6 +6,7 @@ using System.Windows.Threading;
 using Microsoft.Html.Editor.Intellisense;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.Editor;
+using Microsoft.VisualStudio.Language.Intellisense;
 
 namespace MadsKristensen.EditorExtensions.Html
 {
@@ -120,27 +121,24 @@ namespace MadsKristensen.EditorExtensions.Html
         {
             Dispatcher.CurrentDispatcher.BeginInvoke(new Action(() =>
             {
-                if (context == null || context.Session == null || context.Session.CompletionSets == null || context.Session.CompletionSets.Count == 0)
-                    return;
+                //the getter for context.Session.CompletionSets can throw an exception, so checking for null is not good enough to prevent crashes
+                IList<Completion> completions = null;
 
-                var completions = context.Session.CompletionSets[0].Completions;
-
-                if (completions == null)
-                    return;
-
-                for (int i = completions.Count - 1; i >= 0; i--)
+                try
                 {
-                    var item = completions[i] as HtmlCompletion;
-
-                    if (item != null && IsMatch(item.DisplayText))
-                    {
-                        //if (!IsAllowed(item.DisplayText, context.Element))
-                        //    completions.RemoveAt(i);
-                        //else
-                        item.IconSource = _icon;
-                    }
+                    completions = context.Session.CompletionSets[0].Completions;
+                }
+                catch
+                {
+                    return;
                 }
 
+                foreach (var completion in completions.Where(r => IsMatch(r.DisplayText)))
+                {
+                    var item = completion as HtmlCompletion;
+                    if (item != null)
+                        item.IconSource = _icon;
+                }
             }), DispatcherPriority.Normal, null);
 
             return new List<HtmlCompletion>();


### PR DESCRIPTION
This method was checking for nulls, problem was that context.Session.CompletionSets could it self throw a null reference exception.  This would cause visual studio to crash.  Changed to a try catch block and refactored the method a bit.
