### PR TITLE
Change CRLF casing to match EditorConfig schema

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@
 root = true
 
 [*]
-end_of_line = CRLF
+end_of_line = crlf
 indent_style = space
 indent_size = 4
 


### PR DESCRIPTION
Tried to use the file as a template in an unrelated C# project, but found that opening the config file actually showed a schema error for the "CRLF" option. It appears all options are expected to be lowercase in the EditorConfig file.
