### PR TITLE
fix for #1674 - Handlebars template variable name

### DIFF
--- a/EditorExtensions/Handlebars/Compilers/HandlebarsCompiler.cs
+++ b/EditorExtensions/Handlebars/Compilers/HandlebarsCompiler.cs
@@ -21,9 +21,14 @@ namespace MadsKristensen.EditorExtensions.Handlebars
             parameters.Add("service", ServiceName);
             parameters.Add("sourceFileName", sourceFileName);
             parameters.Add("targetFileName", targetFileName);
-            parameters.Add("compiledTemplateName", Path.GetFileNameWithoutExtension(sourceFileName));
+            parameters.Add("compiledTemplateName", CleanTemplateNameForJs(Path.GetFileNameWithoutExtension(sourceFileName)));
 
             return parameters.FlattenParameters();
+        }
+
+        private string CleanTemplateNameForJs(string templateName)
+        {
+            return templateName.Replace("-", "_");
         }
     }
 }

--- a/EditorExtensions/WebEssentials2013.csproj
+++ b/EditorExtensions/WebEssentials2013.csproj
@@ -229,6 +229,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="WebMarkupMin.Core">
+      <HintPath>..\packages\WebMarkupMin.Core.0.9.7\lib\net40\WebMarkupMin.Core.dll</HintPath>
       <HintPath>..\packages\WebMarkupMin.Core.0.9.8\lib\net40\WebMarkupMin.Core.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />


### PR DESCRIPTION
Contains a fix for Handlebars compiler creating invalid variable name when filenames containe "-".

Bug report: #1674 
