### PR TITLE
Bypass hard-coded no-proxy restrictions on localhost to allow Fiddler debugging

### DIFF
--- a/EditorExtensions/Shared/Compilers/ServerBase.cs
+++ b/EditorExtensions/Shared/Compilers/ServerBase.cs
@@ -21,7 +21,7 @@ namespace MadsKristensen.EditorExtensions
         protected ServerBase(string processStartArgumentsFormat, string serverPath)
         {
             SelectAvailablePort();
-            _address = string.Format(CultureInfo.InvariantCulture, "http://127.0.0.1:{0}/", BasePort);
+            _address = string.Format(CultureInfo.InvariantCulture, "http://localhost.:{0}/", BasePort);
             Client = new HttpClient();
 
             Initialize(processStartArgumentsFormat, serverPath);


### PR DESCRIPTION
As discussed in the Fiddler book (http://fiddlerbook.com/fiddler/help/hookup.asp#Q-LocalTraffic), `System.Net.Http.HttpClient` is hard-coded to avoid proxies when `localhost` or `127.0.0.1` is provided as the address.  

Using `localhost.` seems to be the most universal fix for this, as it will resolve whether or not Fiddler (or any other local proxy) is actually running.