### PR TITLE
Fixed RegExp for splitting JsDoc lines

### DIFF
--- a/EditorExtensions/Resources/Scripts/JSDocComments.js
+++ b/EditorExtensions/Resources/Scripts/JSDocComments.js
@@ -149,7 +149,7 @@
         }
     }
 
-    var splitAtRegExp = /[\s*]*[\r\n][\w*]*/;
+    var splitAtRegExp = /[\s*]*[\r\n][\s*]*/;
 
     function processComment(commentString) {
         //replace the first "*" with a "*\r\n"


### PR DESCRIPTION
I see that another change was made to attempt to fix this, but the RegExp was still incorrect. This version splits JsDocs lines correctly. No unit test, but I've been making this exact change locally in on my daily development system for months. 