### PR TITLE
Modified dependency on .NET 4.5 to .NET [4.5,)

### DIFF
--- a/EditorExtensions/Source.extension.vsixmanifest
+++ b/EditorExtensions/Source.extension.vsixmanifest
@@ -17,7 +17,7 @@
         <InstallationTarget Id="Microsoft.VisualStudio.VWDExpress" Version="12.0.31101" />
     </Installation>
     <Dependencies>
-        <!--<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
+        <!--<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
         <Dependency Id="Microsoft.VisualStudio.MPF.12.0" DisplayName="Visual Studio MPF 12.0" d:Source="Installed" Version="[12.0,13.0)" />
         <Dependency d:Source="Installed" Id="0AC2ABB1-6383-4608-BA51-B58A23DD9E8A" DisplayName="Microsoft ASP.NET and Web Tools" Version="[12.3,12.4)" />-->
     </Dependencies>


### PR DESCRIPTION
Web Essentials 2013 cannot currently be installed on systems where Visual Studio 2015 CTP has been installed side by side with VS 2013, since Visual Studio 2015 performs an in place upgrade of .NET 4.5 to .NET 4.5.3. The extension.vsixmanifest, however, explicitly targets 4.5. Changing to [4.5,) resolves #1737.