### PR TITLE
Change image size calculation

### DIFF
--- a/EditorExtensions/CSS/QuickInfo/Image/ImageQuickInfo.cs
+++ b/EditorExtensions/CSS/QuickInfo/Image/ImageQuickInfo.cs
@@ -172,7 +172,7 @@ namespace MadsKristensen.EditorExtensions
             var size = WebEditor.ExportProvider.GetExport<ITextBufferFactoryService>().Value.CreateTextBuffer();
             size.SetText("Loading...");
 
-            source.OnDownloaded(() => size.SetText(Math.Round(source.Width) + "×" + Math.Round(source.Height)));
+            source.OnDownloaded(() => size.SetText(source.PixelWidth + "×" + source.PixelHeight));
             if (source.IsDownloading)
             {
                 EventHandler<System.Windows.Media.ExceptionEventArgs> failure = (s, e) =>


### PR DESCRIPTION
I've found a bug when image size is calculated improperly for some of the PhotoShop-generated PNG images. I'm attaching one such image to the issue.

I've found that the problem with image calculation is the problem with incorrectly (IMHO) used [`BitmapSource.Width` property](https://msdn.microsoft.com/en-us/library/system.windows.media.imaging.bitmapsource.width(v=vs.110).aspx). I've used the `PixelWidth` and `PixelHeight` instead and I got the proper results for the test image.

Here is the image (it has physical size `46x49` but is incorrectly shown as `61x65` by the actual Web Essentials):
![pixels](https://cloud.githubusercontent.com/assets/92793/5979857/807944d0-a8d5-11e4-88e8-7195a4704f1b.png)

To test the issue I've created the followed CSS file:

```css
.my-class {
    background: url('pixels.png');
}
```

When I'm hovering mouse cursor over `pixels.png` I can see incorrect size in the tooltip window.

Please note that this image is rendered using _phisical_ (i.e. `46x49`) size by the web browsers. So the Web Essentials user wants to know this size and not another one.