### PR TITLE
Better support of Unicode/ANSI markdown files without BOM

### DIFF
--- a/EditorExtensions/Markdown/Margin/MarkdownMargin.cs
+++ b/EditorExtensions/Markdown/Margin/MarkdownMargin.cs
@@ -234,8 +234,8 @@ namespace MadsKristensen.EditorExtensions.Markdown
 
             if (htmlTemplateFilePath != null)
             {
-                var solutionPathUrl = ConvertLocalDirectoryPathToUrl(solutionPath);
-                var projectPathUrl = ConvertLocalDirectoryPathToUrl(projectPath);
+                var solutionPathUrl = solutionPath == null ?  currentDocumentPathUrl : ConvertLocalDirectoryPathToUrl(solutionPath);
+                var projectPathUrl = projectPath == null ? currentDocumentPathUrl : ConvertLocalDirectoryPathToUrl(projectPath);
 
                 //Load the template and replace the placeholder with the generated html
                 var htmlTemplate = File.ReadAllText(htmlTemplateFilePath);

--- a/EditorExtensions/Shared/Compilers/CompilerNotifierProviders.cs
+++ b/EditorExtensions/Shared/Compilers/CompilerNotifierProviders.cs
@@ -17,7 +17,7 @@ namespace MadsKristensen.EditorExtensions.Compilers
         public ICompilationNotifier GetCompilationNotifier(ITextDocument doc)
         {
             return doc.TextBuffer.Properties.GetOrCreateSingletonProperty<EditorCompilerInvoker>(
-                       () => new EditorCompilerInvoker(doc, new MarkdownCompilerRunner(doc.TextBuffer.ContentType))
+                       () => new EditorCompilerInvoker(doc, new MarkdownCompilerRunner(doc.TextBuffer.ContentType, doc))
                    );
         }
     }

--- a/EditorExtensions/Shared/Compilers/CompilerRunner.cs
+++ b/EditorExtensions/Shared/Compilers/CompilerRunner.cs
@@ -263,7 +263,8 @@ namespace MadsKristensen.EditorExtensions.Compilers
 
         protected async override Task<CompilerResult> RunCompilerAsync(string sourcePath, string targetPath)
         {
-            var sourceText = await FileHelpers.ReadAllTextRetry(sourcePath, _document.Encoding);
+            Encoding encoding = _document == null ? null : _document.Encoding;
+            var sourceText = await FileHelpers.ReadAllTextRetry(sourcePath, encoding);
             var settings = new CommonMark.CommonMarkSettings
             {
                 OutputFormat = CommonMark.OutputFormat.Html
@@ -271,7 +272,7 @@ namespace MadsKristensen.EditorExtensions.Compilers
             var result = CommonMark.CommonMarkConverter.Convert(sourceText, settings);
 
             if (!string.IsNullOrEmpty(targetPath) &&
-               (!File.Exists(targetPath) || await FileHelpers.ReadAllTextRetry(targetPath, _document.Encoding) != result))
+               (!File.Exists(targetPath) || await FileHelpers.ReadAllTextRetry(targetPath, encoding) != result))
             {
                 ProjectHelpers.CheckOutFileFromSourceControl(targetPath);
 

--- a/EditorExtensions/Shared/Compilers/CompilerRunner.cs
+++ b/EditorExtensions/Shared/Compilers/CompilerRunner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using EnvDTE;
 using MadsKristensen.EditorExtensions.CoffeeScript;
@@ -11,6 +12,7 @@ using MadsKristensen.EditorExtensions.IcedCoffeeScript;
 using MadsKristensen.EditorExtensions.LiveScript;
 using MadsKristensen.EditorExtensions.Settings;
 using MadsKristensen.EditorExtensions.SweetJs;
+using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.Editor;
 
@@ -249,13 +251,19 @@ namespace MadsKristensen.EditorExtensions.Compilers
     ///<summary>Compiles files asynchronously using MarkdownSharp and reports the results.</summary>
     class MarkdownCompilerRunner : CompilerRunnerBase
     {
-        public MarkdownCompilerRunner(IContentType contentType) : base(contentType) { }
+        private readonly ITextDocument _document;
+
+        public MarkdownCompilerRunner(IContentType contentType, ITextDocument document = null) : base(contentType) 
+        {
+            _document = document;
+        }
+
         public override bool GenerateSourceMap { get { return false; } }
         public override string TargetExtension { get { return ".html"; } }
 
         protected async override Task<CompilerResult> RunCompilerAsync(string sourcePath, string targetPath)
         {
-            var sourceText = await FileHelpers.ReadAllTextRetry(sourcePath);
+            var sourceText = await FileHelpers.ReadAllTextRetry(sourcePath, _document.Encoding);
             var settings = new CommonMark.CommonMarkSettings
             {
                 OutputFormat = CommonMark.OutputFormat.Html
@@ -263,7 +271,7 @@ namespace MadsKristensen.EditorExtensions.Compilers
             var result = CommonMark.CommonMarkConverter.Convert(sourceText, settings);
 
             if (!string.IsNullOrEmpty(targetPath) &&
-               (!File.Exists(targetPath) || await FileHelpers.ReadAllTextRetry(targetPath) != result))
+               (!File.Exists(targetPath) || await FileHelpers.ReadAllTextRetry(targetPath, _document.Encoding) != result))
             {
                 ProjectHelpers.CheckOutFileFromSourceControl(targetPath);
 

--- a/EditorExtensions/Shared/Helpers/FileHelpers.cs
+++ b/EditorExtensions/Shared/Helpers/FileHelpers.cs
@@ -305,7 +305,7 @@ namespace MadsKristensen.EditorExtensions
         /// </summary>
         /// <param name="fileName">The file to open for reading.</param>
         /// <returns>Task which ultimately returns a string containing all lines of the file.</returns>
-        public async static Task<string> ReadAllTextRetry(string fileName)
+        public async static Task<string> ReadAllTextRetry(string fileName, Encoding encoding = null)
         {
             if (string.IsNullOrEmpty(fileName))
                 return null;
@@ -318,8 +318,13 @@ namespace MadsKristensen.EditorExtensions
 
             try
             {
+                // Keep the previous behavior if no encoding is provided.
                 return await PolicyFactory.GetPolicy(new FileTransientErrorDetectionStrategy(), retryCount)
-                            .ExecuteAsync(() => Task.FromResult<string>(File.ReadAllText(fileName)));
+                            .ExecuteAsync(() =>
+                                    encoding == null ? 
+                                    Task.FromResult<string>(File.ReadAllText(fileName)) :
+                                    Task.FromResult<string>(File.ReadAllText(fileName, encoding)) 
+                                );
             }
             catch (IOException)
             {


### PR DESCRIPTION
Fix Issue #1762 

This fix also a bug that was causing a NullReferenceException when a markdown file that was not part of a project or solution was opened and the code attempted to get the Active Project path.