### PR TITLE
Source maps generation

### DIFF
--- a/EditorExtensions/Misc/RTLCss/Compilers/RtlCssCompiler.cs
+++ b/EditorExtensions/Misc/RTLCss/Compilers/RtlCssCompiler.cs
@@ -26,6 +26,9 @@ namespace MadsKristensen.EditorExtensions.RtlCss
             parameters.UriComponentsDictionary.Add("targetFileName", targetFileName);
             parameters.Add("mapFileName", targetFileName + ".map");
 
+            if (GenerateSourceMap)
+                parameters.Add("sourceMapURL");
+
             if (WESettings.Instance.Css.RtlCss)
                 parameters.Add("rtlcss");
 

--- a/EditorExtensions/Resources/server/services/srv-autoprefixer.js
+++ b/EditorExtensions/Resources/server/services/srv-autoprefixer.js
@@ -27,7 +27,7 @@ var processAutoprefixer = function (cssContent, mapContent, browsers, sourceFile
         };
 
     result = result.process(cssContent, {
-        map: { prev: mapContent },
+        map: { prev: mapContent, inline: false },
         from: sourceFileName,
         to: targetFileName
     });

--- a/EditorExtensions/Resources/server/services/srv-scss.js
+++ b/EditorExtensions/Resources/server/services/srv-scss.js
@@ -5,6 +5,8 @@ var sass = require("node-sass"),
 
 //#region Handler
 var handleSass = function (writer, params) {
+    var omitSourceMap = typeof params.sourceMapURL === 'undefined';
+
     sass.render({
         file: params.sourceFileName,
         outFile: params.targetFileName,
@@ -12,10 +14,11 @@ var handleSass = function (writer, params) {
         precision: parseInt(params.precision, 10),
         outputStyle: params.outputStyle,
         sourceMap: params.mapFileName,
-        omitSourceMapUrl: params.sourceMapURL === undefined,
+        omitSourceMapUrl: omitSourceMap,
         success: function (result) {
-            var css = result.css;
-            var map = result.map;
+            var css = result.css, map;
+            if (!omitSourceMap)
+                map = result.map;
 
             if (params.autoprefixer !== undefined) {
                 var autoprefixedOutput = require("./srv-autoprefixer")

--- a/EditorExtensions/Resources/server/services/srv-scss.js
+++ b/EditorExtensions/Resources/server/services/srv-scss.js
@@ -35,8 +35,9 @@ var handleSass = function(writer, params) {
             writer.end();
         }
 
-        var css = result.css.toString();
-        var map = result.map.toString();
+        var map, css = result.css.toString();
+        if (!options.omitSourceMapUrl)
+            map = result.map.toString();
 
         if (params.autoprefixer !== undefined) {
             var autoprefixedOutput = require("./srv-autoprefixer")


### PR DESCRIPTION
1. Make sure generated source maps are not inline.
   
   > As of [postcss 3.0](https://github.com/postcss/postcss/releases/tag/3.0.0) `map.inline` is enabled by default, which will cause source maps to be embedded inside the processed file.
2. Respect `Scss`.`GenerateSourceMaps` flag.
3. Respect `Css`.`GenerateRtlSourceMaps` flag.

To ensure services compatibility in the future, May be the build task should fix the major version of the downloaded node packages.

Related: #1726

Thanks.
