### PR TITLE
Fix for issue #1785

### DIFF
--- a/EditorExtensions/Misc/MenuItems/BundleFiles.cs
+++ b/EditorExtensions/Misc/MenuItems/BundleFiles.cs
@@ -64,8 +64,8 @@ namespace MadsKristensen.EditorExtensions
 
             _files = ProjectHelpers.GetSelectedFilePaths();
 
-            menuCommand.Enabled = _files.All(file => extensions.Contains(Path.GetExtension(file))) &&
-                                  _files.Count() > 1;
+            menuCommand.Enabled = _files.Any(file => extensions.Contains(Path.GetExtension(file))) &&
+                          _files.Count(file => extensions.Contains(Path.GetExtension(file))) > 1;
         }
 
         private bool GetFileName(out string fileName, string extension)
@@ -185,7 +185,7 @@ namespace MadsKristensen.EditorExtensions
 
             try
             {
-                BundleDocument doc = new BundleDocument(bundleFile, _files.ToArray());
+                BundleDocument doc = new BundleDocument(bundleFile, _files.Where(file => Path.GetExtension(file) == extension).ToArray());
 
                 await doc.WriteBundleRecipe();
                 await GenerateAsync(doc, extension);


### PR DESCRIPTION
This change allows bundles to be created from selections that contain files other than the type being bundled, as long as there are at least two files of the correct type selected.

Only the files of the correct type will actually be added to the bundle, all others will be ignored..