### PR TITLE
Feature: Zen representation for Html and RazorHtml files

### DIFF
--- a/EditorExtensions/CSS/Validation/Providers/UnknownTagErrorTagProvider.cs
+++ b/EditorExtensions/CSS/Validation/Providers/UnknownTagErrorTagProvider.cs
@@ -33,18 +33,18 @@ namespace MadsKristensen.EditorExtensions.Css
         {
             var ignoreList = includeUnstyled ? _cssIgnore : _basicIgnore;
 
-            foreach (var schema in Schemas)
-                foreach (var element in schema.GetTopLevelElements())
-                {
-                    if (!ignoreList.Contains(element.Name))
-                        yield return new CompletionListEntry(element.Name) { Description = element.Description.Description };
-
-                    foreach (var child in element.GetChildren())
+            foreach (var schema in Schemas) if (schema != null)
+                    foreach (var element in schema.GetTopLevelElements())
                     {
-                        if (!ignoreList.Contains(child.Name))
-                            yield return new CompletionListEntry(child.Name) { Description = child.Description.Description };
+                        if (!ignoreList.Contains(element.Name))
+                            yield return new CompletionListEntry(element.Name) { Description = element.Description.Description };
+
+                        foreach (var child in element.GetChildren())
+                        {
+                            if (!ignoreList.Contains(child.Name))
+                                yield return new CompletionListEntry(child.Name) { Description = child.Description.Description };
+                        }
                     }
-                }
         }
 
         public static IEnumerable<IHtmlSchema> Schemas

--- a/EditorExtensions/RazorZen/Classify/RazorZenClassificationTypes.cs
+++ b/EditorExtensions/RazorZen/Classify/RazorZenClassificationTypes.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.Utilities;
+using System;
+using System.ComponentModel.Composition;
+
+namespace MadsKristensen.EditorExtensions.RazorZen
+{
+    public static class RazorZenClassificationTypes
+    {
+        public const string ZenTag = "RazorZen_ZenTag";
+        public const string ZenAttributName = "RazorZen_ZenAttributName";
+        public const string ZenAttributValue = "RazorZen_ZenAttributValue";
+
+        public const string RazorStart = "RazorZen_RazorStart";
+
+        [Export, Name(RazorZenClassificationTypes.ZenAttributName)]
+        public static ClassificationTypeDefinition RazorZenClassificationZenAttributName { get; set; }
+
+        [Export, Name(RazorZenClassificationTypes.ZenTag)]
+        public static ClassificationTypeDefinition RazorZenClassificationZenTag { get; set; }
+
+        [Export, Name(RazorZenClassificationTypes.ZenAttributValue)]
+        public static ClassificationTypeDefinition RazorZenClassificationZenAttributValue { get; set; }
+
+        [Export, Name(RazorZenClassificationTypes.RazorStart)]
+        public static ClassificationTypeDefinition RazorZenClassificationRazorStart { get; set; }
+    }
+
+    [Export(typeof(EditorFormatDefinition))]
+    [ClassificationType(ClassificationTypeNames = RazorZenClassificationTypes.ZenTag)]
+    [Name(RazorZenClassificationTypes.ZenTag)]
+    [Order(After = Priority.Default)]
+    [UserVisible(true)]
+    internal sealed class RazorZenZenTagsFormatDefinition : ClassificationFormatDefinition
+    {
+        public RazorZenZenTagsFormatDefinition()
+        {
+            ForegroundColor = System.Windows.Media.Colors.Brown;
+            DisplayName = "RazorZen Zen Tags";
+        }
+    }
+
+    [Export(typeof(EditorFormatDefinition))]
+    [ClassificationType(ClassificationTypeNames = RazorZenClassificationTypes.ZenAttributName)]
+    [Name(RazorZenClassificationTypes.ZenAttributName)]
+    [Order(After = Priority.Default)]
+    [UserVisible(true)]
+    internal sealed class RazorZenZenAttibuteNamesFormatDefinition : ClassificationFormatDefinition
+    {
+        public RazorZenZenAttibuteNamesFormatDefinition()
+        {
+            ForegroundColor = System.Windows.Media.Colors.Red;
+            DisplayName = "RazorZen Zen Attribute Names";
+        }
+    }
+
+    [Export(typeof(EditorFormatDefinition))]
+    [ClassificationType(ClassificationTypeNames = RazorZenClassificationTypes.ZenAttributValue)]
+    [Name(RazorZenClassificationTypes.ZenAttributValue)]
+    [Order(After = Priority.Default)]
+    [UserVisible(true)]
+    internal sealed class RazorZenZenAttributeValuesFormatDefinition : ClassificationFormatDefinition
+    {
+        public RazorZenZenAttributeValuesFormatDefinition()
+        {
+            ForegroundColor = System.Windows.Media.Colors.Blue;
+            DisplayName = "RazorZen Zen Attribute Values";
+        }
+    }
+
+    [Export(typeof(EditorFormatDefinition))]
+    [ClassificationType(ClassificationTypeNames = RazorZenClassificationTypes.RazorStart)]
+    [Name(RazorZenClassificationTypes.RazorStart)]
+    [Order(After = Priority.Default)]
+    [UserVisible(true)]
+    internal sealed class RazorZenRazorStartFormatDefinition : ClassificationFormatDefinition
+    {
+        public RazorZenRazorStartFormatDefinition()
+        {
+            BackgroundColor = System.Windows.Media.Colors.Yellow;
+            DisplayName = "RazorZen Razor Start";
+        }
+    }
+}

--- a/EditorExtensions/RazorZen/Classify/RazorZenClassifier.cs
+++ b/EditorExtensions/RazorZen/Classify/RazorZenClassifier.cs
@@ -1,0 +1,214 @@
+﻿using Microsoft.VisualStudio.Language.StandardClassification;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace MadsKristensen.EditorExtensions.RazorZen
+{
+    public class RazorZenClassifier : IClassifier
+    {
+        private static List<char> zenAttributes = new List<char>() { '#', '.' };
+        private static List<string> commentStarts = new List<string>() { "!-", "@*" };
+        private static List<string> commentEnds = new List<string>() { "-!", "*@" };
+        private IClassificationType _razorStart;
+        private IClassificationType _comment;
+        private IClassificationType _zenTag;
+        private IClassificationType _zenAttributeName;
+        private IClassificationType _zenAttributeValue;
+
+        public RazorZenClassifier(IClassificationTypeRegistryService registry)
+        {
+            _razorStart = registry.GetClassificationType(RazorZenClassificationTypes.RazorStart);
+            _comment = registry.GetClassificationType(PredefinedClassificationTypeNames.Comment);
+            _zenTag = registry.GetClassificationType(RazorZenClassificationTypes.ZenTag);
+            _zenAttributeName = registry.GetClassificationType(RazorZenClassificationTypes.ZenAttributName);
+            _zenAttributeValue = registry.GetClassificationType(RazorZenClassificationTypes.ZenAttributValue);
+        }
+
+        public event EventHandler<ClassificationChangedEventArgs> ClassificationChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public IList<ClassificationSpan> GetClassificationSpans(SnapshotSpan span)
+        {
+            var list = new List<ClassificationSpan>();
+
+            var text = span.GetText();
+
+            {  // Razor Starts
+                var i = 0;
+                while (i < text.Length)
+                {
+                    i = text.IndexOf("@", i);
+
+                    if (i == -1) break;
+
+                    var razorStart = new SnapshotSpan(span.Snapshot, span.Start + i, 1);
+                    list.Add(new ClassificationSpan(razorStart, _razorStart));
+
+                    i++;
+                }
+
+                i = 0;
+                while (i < text.Length)
+                {
+                    i = text.IndexOf("@*", i);
+
+                    if (i == -1) break;
+
+                    var razorStart = new SnapshotSpan(span.Snapshot, span.Start + i, 2);
+                    list.Add(new ClassificationSpan(razorStart, _razorStart));
+
+                    i += 2;
+                }
+
+                i = 0;
+                while (i < text.Length)
+                {
+                    i = text.IndexOf("*@", i);
+
+                    if (i == -1) break;
+
+                    var razorStart = new SnapshotSpan(span.Snapshot, span.Start + i, 2);
+                    list.Add(new ClassificationSpan(razorStart, _razorStart));
+
+                    i += 2;
+                }
+            }
+
+            {  // Razor Comments
+                var start = text.IndexOf("@*");
+                var end = text.LastIndexOf("*@");
+
+                if (start > -1 && end > -1 && start < end)
+                {
+                    var comment = new SnapshotSpan(span.Snapshot, span.Start + start + 2, (end - start) - 2);
+                    list.Add(new ClassificationSpan(comment, _comment));
+                }
+            }
+
+            {  // Zen Comments
+                var start = text.IndexOf("!-");
+                var end = text.LastIndexOf("-!");
+
+                if (start > -1 && end > -1 && start < end)
+                {
+                    var comment = new SnapshotSpan(span.Snapshot, span.Start + start, span.Length - (start - end));
+                    list.Add(new ClassificationSpan(comment, _comment));
+                }
+            }
+
+            { //Tag Names
+                var tagsRegex = new Regex(" ([\\w|-|_]+)[#|\\.|\\[|{| |\r|\n]",
+                    RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+                // Match the regular expression pattern against a text string.
+                var m = tagsRegex.Match(text);
+
+                while (m.Success)
+                {
+                    var g = m.Groups[1];
+
+                    var numberOfOpens = text.Substring(0, g.Index).Split(new[] { "[", "{", "(", "!-", "@*" }, StringSplitOptions.None).Length - 1;
+                    var numberOfCloses = text.Substring(0, g.Index).Split(new[] { "]", "}", ")", "-!", "*@" }, StringSplitOptions.None).Length - 1;
+
+                    if (numberOfOpens == numberOfCloses)
+                    {
+                        var zenTagName = new SnapshotSpan(span.Snapshot, span.Start + g.Index, g.Length);
+                        list.Add(new ClassificationSpan(zenTagName, _zenTag));
+                    }
+
+                    m = m.NextMatch();
+                }
+            }
+
+            { // Attribut Values from id and classes
+                var tagsRegex = new Regex("[#|\\.]([\\w|\\-|_]+[^#\\.\\[{ ])",
+                        RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+                // Match the regular expression pattern against a text string.
+                var m = tagsRegex.Match(text);
+
+                while (m.Success)
+                {
+                    var g = m.Groups[1];
+
+                    var numberOfOpens = text.Substring(0, g.Index).Split(new[] { "[", "{", "(", "!-", "@*" }, StringSplitOptions.None).Length - 1;
+                    var numberOfCloses = text.Substring(0, g.Index).Split(new[] { "]", "}", ")", "-!", "*@" }, StringSplitOptions.None).Length - 1;
+
+                    if (numberOfOpens == numberOfCloses)
+                    {
+                        var zenTAttributValue = new SnapshotSpan(span.Snapshot, span.Start + g.Index, g.Length);
+                        list.Add(new ClassificationSpan(zenTAttributValue, _zenAttributeValue));
+                    }
+                    m = m.NextMatch();
+                }
+            }
+
+            { // Attribute Names
+                for (int i = 0; i < text.Length; i++)
+                {
+                    var c = text[i];
+
+                    if (zenAttributes.Contains(c))
+                    {
+                        var numberOfOpens = text.Substring(0, i).Split(new[] { "[", "{", "(", "!-", "@*" }, StringSplitOptions.None).Length - 1;
+                        var numberOfCloses = text.Substring(0, i).Split(new[] { "]", "}", ")", "-!", "*@" }, StringSplitOptions.None).Length - 1;
+
+                        if (numberOfOpens == numberOfCloses)
+                        {
+                            var zenAttributeName = new SnapshotSpan(span.Snapshot, span.Start + i, 1);
+                            list.Add(new ClassificationSpan(zenAttributeName, _zenAttributeName));
+                        }
+                    }
+                }
+            }
+
+            {  // Attribut Names & Values
+                var i = 0;
+                while (i < text.Length)
+                {
+                    var attributesStart = text.IndexOf("[", i);
+                    if (attributesStart == -1) break;
+
+                    var attributesEnd = text.IndexOf("]", attributesStart + 1);
+                    if (attributesEnd == -1) break;
+
+                    var ii = attributesStart + 1;
+                    while (ii < attributesEnd)
+                    {
+                        var startValue = text.IndexOf("=\"", ii);
+                        if (startValue == -1) break;
+
+                        var endValue = text.IndexOf(" ", startValue + 1);
+                        if (endValue == -1)
+                        {
+                            endValue = attributesEnd - 1;
+                        }
+
+                        var zenAttributeValueStart = new SnapshotSpan(span.Snapshot, span.Start + ii, startValue - ii);
+                        list.Add(new ClassificationSpan(zenAttributeValueStart, _zenAttributeName));
+
+                        var zenAttributeValueEnd = new SnapshotSpan(span.Snapshot, span.Start + startValue, endValue - startValue);
+                        list.Add(new ClassificationSpan(zenAttributeValueEnd, _zenAttributeValue));
+
+                        ii = endValue + 1;
+                    }
+
+                    var zenAttributesStart = new SnapshotSpan(span.Snapshot, span.Start + attributesStart, 1);
+                    list.Add(new ClassificationSpan(zenAttributesStart, _zenAttributeValue));
+
+                    var zenAttributesEnd = new SnapshotSpan(span.Snapshot, span.Start + attributesEnd, 1);
+                    list.Add(new ClassificationSpan(zenAttributesEnd, _zenAttributeValue));
+
+                    i = attributesEnd + 1;
+                }
+            }
+            return list;
+        }
+    }
+}

--- a/EditorExtensions/RazorZen/Classify/RazorZenClassifierProvider.cs
+++ b/EditorExtensions/RazorZen/Classify/RazorZenClassifierProvider.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.Utilities;
+using System.ComponentModel.Composition;
+
+namespace MadsKristensen.EditorExtensions.RazorZen
+{
+    [Export(typeof(IClassifierProvider))]
+    [ContentType(RazorZenContentTypeDefinition.RazorZenContentType)]
+    public class RazorZenClassifierProvider : IClassifierProvider
+    {
+        [Import]
+        public IClassificationTypeRegistryService Registry { get; set; }
+
+        public IClassifier GetClassifier(ITextBuffer textBuffer)
+        {
+            return textBuffer.Properties.GetOrCreateSingletonProperty(() => new RazorZenClassifier(Registry));
+        }
+    }
+}

--- a/EditorExtensions/RazorZen/Commands/RazorZenCreationListener.cs
+++ b/EditorExtensions/RazorZen/Commands/RazorZenCreationListener.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.Utilities;
+using System.ComponentModel.Composition;
+
+namespace MadsKristensen.EditorExtensions.RazorZen
+{
+    [Export(typeof(IVsTextViewCreationListener))]
+    [ContentType(RazorZenContentTypeDefinition.RazorZenContentType)]
+    [TextViewRole(PredefinedTextViewRoles.Document)]
+    public class RazorZenViewCreationListener : IVsTextViewCreationListener
+    {
+        [Import]
+        public IVsEditorAdaptersFactoryService EditorAdaptersFactoryService { get; set; }
+
+        public void VsTextViewCreated(IVsTextView textViewAdapter)
+        {
+            var textView = EditorAdaptersFactoryService.GetWpfTextView(textViewAdapter);
+
+            textView.Properties.GetOrCreateSingletonProperty(() => new CommentCommandTarget(textViewAdapter, textView, "#"));
+        }
+    }
+}

--- a/EditorExtensions/RazorZen/ContentType/RazorZenContentTypeDefinition.cs
+++ b/EditorExtensions/RazorZen/ContentType/RazorZenContentTypeDefinition.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.VisualStudio.Utilities;
+using System.ComponentModel.Composition;
+
+namespace MadsKristensen.EditorExtensions.RazorZen
+{
+    public class RazorZenContentTypeDefinition
+    {
+        public const string RazorZenContentType = "RazorZen";
+
+        /// <summary>
+        /// Exports the RazorZen HTML content type
+        /// </summary>
+        [Export(typeof(ContentTypeDefinition))]
+        [Name(RazorZenContentType)]
+        [BaseDefinition("plaintext")]
+        public ContentTypeDefinition IRazorZenContentType { get; set; }
+
+        [Export(typeof(FileExtensionToContentTypeDefinition))]
+        [ContentType(RazorZenContentType)]
+        [FileExtension(".cszen")]
+        public FileExtensionToContentTypeDefinition RazorZenFileExtension { get; set; }
+    }
+}

--- a/EditorExtensions/RazorZen/Converter/RazorZenConverter.cs
+++ b/EditorExtensions/RazorZen/Converter/RazorZenConverter.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace MadsKristensen.EditorExtensions.RazorZen.Converter
+{
+    public class RazorZenConverter
+    {
+        public string Convert(string source)
+        {
+            var target = source.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+
+            for (int i = 0; i < target.Length; i++)
+            {
+                var line = target[i];
+
+                // Comments
+                line = line.Replace("<!--", "!-")
+                    .Replace("-->", "-!");
+
+                // Add Space before child
+                line = Regex.Replace(line,
+                     "(<[^\\/]+>)(<[^\\/]+>)",
+                     "$1 $2",
+                     RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+                // Textnodes
+                line = Regex.Replace(line,
+                     "(<[^\\/][^<>]+>)(([^<>])+)<\\/",
+                     "$1{$2}</",
+                     RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+                // Ids
+                {
+                    var classesRegex = new Regex("<[^\\/>]+( id=\")([^>\"]+)(\")[^>]*>",
+                        RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+                    // Match the regular expression pattern against a text string.
+                    var m = classesRegex.Match(line);
+
+                    while (m.Success)
+                    {
+                        // Remove suffix "
+                        var g = m.Groups[3];
+                        line = line.Remove(g.Index, g.Length);
+
+                        // Replace id1 with #id1
+                        g = m.Groups[2];
+                        line = line.Remove(g.Index, g.Length)
+                             .Insert(g.Index, "#" + g.Value.Trim().Replace(' ', '#'));
+
+                        // Remove Prefix id="
+                        g = m.Groups[1];
+                        line = line.Remove(g.Index, g.Length);
+
+                        m = m.NextMatch();
+                    }
+                }
+
+                // Classes
+                {
+                    var classesRegex = new Regex("<[^\\/>]+( class=\")([^>\"]+)(\")[^>]*>",
+                        RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+                    // Match the regular expression pattern against a text string.
+                    var m = classesRegex.Match(line);
+
+                    while (m.Success)
+                    {
+                        // Remove suffix "
+                        var g = m.Groups[3];
+                        line = line.Remove(g.Index, g.Length);
+
+                        // Replace class1 class2 to .class1.class2
+                        g = m.Groups[2];
+                        line = line.Remove(g.Index, g.Length)
+                             .Insert(g.Index, "." + g.Value.Trim().Replace(' ', '.'));
+
+                        // Remove Prefix class="
+                        g = m.Groups[1];
+                        line = line.Remove(g.Index, g.Length);
+
+                        m = m.NextMatch();
+                    }
+                }
+
+                // Attribtues
+                line = Regex.Replace(line,
+                     "(<[^\\/<> ]+) ([^<>]+>)",
+                     "$1[$2]",
+                     RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+                // Divs
+                line = Regex.Replace(line,
+                     "<div([^<>]*)>",
+                     "$1",
+                     RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+                // Tags
+                line = Regex.Replace(line,
+                     "<([^\\/]([^<>])*)>",
+                     "$1",
+                     RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+                // Close Tags
+                line = Regex.Replace(line,
+                     "<\\/([^<>])*>",
+                     "",
+                     RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+                target[i] = line;
+            }
+
+            return string.Join(Environment.NewLine, target);
+        }
+    }
+}

--- a/EditorExtensions/RazorZen/Margin/RazorZenMargin.cs
+++ b/EditorExtensions/RazorZen/Margin/RazorZenMargin.cs
@@ -1,0 +1,15 @@
+using MadsKristensen.EditorExtensions.Margin;
+using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
+using System;
+using System.Linq;
+
+namespace MadsKristensen.EditorExtensions.RazorZen
+{
+    internal class RazorZenMargin : TextViewMargin
+    {
+        public RazorZenMargin(ITextDocument document, IWpfTextView sourceView)
+            : base(RazorZenContentTypeDefinition.RazorZenContentType, document, sourceView)
+        { }
+    }
+}

--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -218,7 +218,7 @@ namespace MadsKristensen.EditorExtensions.Settings
         public bool ShowPreviewPane { get; set; }
     }
 
-    public sealed class HtmlSettings : SettingsBase<HtmlSettings>, IMinifierSettings, IBundleSettings
+    public sealed class HtmlSettings : SettingsBase<HtmlSettings>, ICompilerInvocationSettings, IMarginSettings, IMinifierSettings, IBundleSettings
     {
         [DisplayName("Auto-format HTML on Enter")]
         [Description("Automatically format HTML source when pressing Enter.")]
@@ -284,6 +284,22 @@ namespace MadsKristensen.EditorExtensions.Settings
 
         [Browsable(false)]
         public ObservableCollection<ImageDropFormat> ImageDropFormats { get; private set; }
+
+        bool ICompilerInvocationSettings.CompileOnSave { get { return false; } }
+
+        bool IMarginSettings.ShowPreviewPane { get { return this.ShowZenPane; } }
+
+        [DisplayName("Show Zen representation")]
+        [Description("Shows a window with a Zen like representation for better reading.")]
+        [DefaultValue(false)]
+        public bool ShowZenPane { get; set; }
+
+        bool ICompilerInvocationSettings.CompileOnBuild { get { return false; } }
+
+        string ICompilerInvocationSettings.OutputDirectory { get { return ""; } }
+
+        bool ICompilerInvocationSettings.MinifyInPlace { get { return false; } }
+
         protected override void ResetCustom()
         {
             ImageDropFormats.Add(new ImageDropFormat("Simple Image Tag", @"<img src=""{0}"" alt="""" />"));

--- a/EditorExtensions/Shared/Compilers/CompilerNotifierProviders.cs
+++ b/EditorExtensions/Shared/Compilers/CompilerNotifierProviders.cs
@@ -22,6 +22,29 @@ namespace MadsKristensen.EditorExtensions.Compilers
         }
     }
 
+    [Export(typeof(ICompilationNotifierProvider))]
+    [ContentType("Htmlx")]
+    internal class HtmlxCompilerNotifierProvider : ICompilationNotifierProvider
+    {
+        public ICompilationNotifier GetCompilationNotifier(ITextDocument doc)
+        {
+            return doc.TextBuffer.Properties.GetOrCreateSingletonProperty<EditorCompilerInvoker>(
+                       () => new EditorCompilerInvoker(doc, new RazorZenCompilerRunner(doc.TextBuffer.ContentType, doc))
+                   );
+        }
+    }
+
+    [Export(typeof(ICompilationNotifierProvider))]
+    [ContentType("Razor")]
+    internal class RazorCompilerNotifierProvider : ICompilationNotifierProvider
+    {
+        public ICompilationNotifier GetCompilationNotifier(ITextDocument doc)
+        {
+            return doc.TextBuffer.Properties.GetOrCreateSingletonProperty<EditorCompilerInvoker>(
+                       () => new EditorCompilerInvoker(doc, new RazorZenCompilerRunner(doc.TextBuffer.ContentType, doc))
+                   );
+        }
+    }
 
     [Export(typeof(ICompilationNotifierProvider))]
     [ContentType(CssContentTypeDefinition.CssContentType)]
@@ -33,7 +56,7 @@ namespace MadsKristensen.EditorExtensions.Compilers
     [ContentType(LiveScriptContentTypeDefinition.LiveScriptContentType)]
     [ContentType(SweetJsContentTypeDefinition.SweetJsContentType)]
     [ContentType(HandlebarsContentTypeDefinition.HandlebarsContentType)]
-    class NodeCompilerNotifierProvider : ICompilationNotifierProvider
+     class NodeCompilerNotifierProvider : ICompilationNotifierProvider
     {
         public ICompilationNotifier GetCompilationNotifier(ITextDocument doc)
         {

--- a/EditorExtensions/Shared/Margins/EditorMarginFactory.cs
+++ b/EditorExtensions/Shared/Margins/EditorMarginFactory.cs
@@ -17,6 +17,8 @@ namespace MadsKristensen.EditorExtensions.Margin
     [Name("MarginFactory")]
     [Order(After = PredefinedMarginNames.RightControl)]
     [MarginContainer(PredefinedMarginNames.Right)]
+    [ContentType(RazorContentTypeDefinition.RazorContentType)]
+    [ContentType(HtmlContentTypeDefinition.HtmlContentType)]
     [ContentType(CssContentTypeDefinition.CssContentType)]
     [ContentType(LessContentTypeDefinition.LessContentType)]
     [ContentType(ScssContentTypeDefinition.ScssContentType)]
@@ -35,6 +37,8 @@ namespace MadsKristensen.EditorExtensions.Margin
 
         static readonly Dictionary<string, Func<ITextDocument, IWpfTextView, IWpfTextViewMargin>> marginFactories = new Dictionary<string, Func<ITextDocument, IWpfTextView, IWpfTextViewMargin>>(StringComparer.OrdinalIgnoreCase)
         {
+            { "htmlx",             (document, sourceView) => new TextViewMargin("RazorZen", document, sourceView, synchronizedViewport: true) },
+            { "RazorCSharp",       (document, sourceView) => new TextViewMargin("RazorZen", document, sourceView, synchronizedViewport: true) },
             { "CoffeeScript",      (document, sourceView) => new TextViewMargin("JavaScript", document, sourceView) },
             { "IcedCoffeeScript",  (document, sourceView) => new TextViewMargin("JavaScript", document, sourceView) },
             { "LiveScript",        (document, sourceView) => new TextViewMargin("JavaScript", document, sourceView) },
@@ -44,7 +48,7 @@ namespace MadsKristensen.EditorExtensions.Margin
             { "SCSS",              (document, sourceView) => new CssTextViewMargin("CSS", document, sourceView) },
             { "Svg",               (document, sourceView) => new SvgMargin(document) },
             { "SweetJs",           (document, sourceView) => new TextViewMargin("JavaScript", document, sourceView) },
-            { "TypeScript",        (document, sourceView) => document.FilePath.EndsWith(".d.ts", StringComparison.OrdinalIgnoreCase) 
+            { "TypeScript",        (document, sourceView) => document.FilePath.EndsWith(".d.ts", StringComparison.OrdinalIgnoreCase)
                                                              ? null : new TextViewMargin("JavaScript", document, sourceView) }
         };
 

--- a/EditorExtensions/StringExtention.cs
+++ b/EditorExtensions/StringExtention.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Linq;
+
+namespace System
+{
+    public static class StringExtention
+    {
+        #region IndexOfAny
+
+        public static int IndexOfAny(this string s, string[] anyOf)
+        {
+            var index = -1;
+
+            foreach (var value in anyOf)
+            {
+                index = s.IndexOf(value);
+
+                if (index > -1)
+                    break;
+            }
+            return index;
+        }
+
+        public static int IndexOfAny(this string s, string[] anyOf, int startIndex)
+        {
+            var index = -1;
+
+            foreach (var value in anyOf)
+            {
+                index = s.IndexOf(value, startIndex);
+
+                if (index > -1)
+                    break;
+            }
+            return index;
+        }
+
+        public static int IndexOfAny(this string s, string[] anyOf, int startIndex, StringComparison comparisonType)
+        {
+            var index = -1;
+
+            foreach (var value in anyOf)
+            {
+                index = s.IndexOf(value, startIndex, comparisonType);
+
+                if (index > -1)
+                    break;
+            }
+            return index;
+        }
+
+        public static int IndexOfAny(this string s, string[] anyOf, int startIndex, int count)
+        {
+            var index = -1;
+
+            foreach (var value in anyOf)
+            {
+                index = s.IndexOf(value, startIndex, count);
+
+                if (index > -1)
+                    break;
+            }
+            return index;
+        }
+
+        public static int IndexOfAny(this string s, string[] anyOf, int startIndex, int count, StringComparison comparisonType)
+        {
+            var index = -1;
+
+            foreach (var value in anyOf)
+            {
+                index = s.IndexOf(value, startIndex, count, comparisonType);
+
+                if (index > -1)
+                    break;
+            }
+            return index;
+        }
+
+        #endregion
+
+        #region LastIndexOfAny
+
+        public static int LastIndexOfAny(this string s, string[] anyOf)
+        {
+            var index = -1;
+
+            foreach (var value in anyOf)
+            {
+                index = s.LastIndexOf(value);
+
+                if (index > -1)
+                    break;
+            }
+            return index;
+        }
+
+        public static int LastIndexOf(this string s, string[] anyOf, int startIndex)
+        {
+            var index = -1;
+
+            foreach (var value in anyOf)
+            {
+                index = s.LastIndexOf(value, startIndex);
+
+                if (index > -1)
+                    break;
+            }
+            return index;
+        }
+
+        public static int LastIndexOf(this string s, string[] anyOf, int startIndex, StringComparison comparisonType)
+        {
+            var index = -1;
+
+            foreach (var value in anyOf)
+            {
+                index = s.LastIndexOf(value, startIndex, comparisonType);
+
+                if (index > -1)
+                    break;
+            }
+            return index;
+        }
+
+        public static int LastIndexOf(this string s, string[] anyOf, int startIndex, int count)
+        {
+            var index = -1;
+
+            foreach (var value in anyOf)
+            {
+                index = s.LastIndexOf(value, startIndex, count);
+
+                if (index > -1)
+                    break;
+            }
+            return index;
+        }
+
+        public static int LastIndexOf(this string s, string[] anyOf, int startIndex, int count, StringComparison comparisonType)
+        {
+            var index = -1;
+
+            foreach (var value in anyOf)
+            {
+                index = s.LastIndexOf(value, startIndex, count, comparisonType);
+
+                if (index > -1)
+                    break;
+            }
+            return index;
+        }
+
+        #endregion
+    }
+}

--- a/EditorExtensions/WebEssentials2013.csproj
+++ b/EditorExtensions/WebEssentials2013.csproj
@@ -403,6 +403,13 @@
     <Compile Include="Misc\Bundles\BundleDocument.cs" />
     <Compile Include="LiveScript\Compilers\LiveScriptCompiler.cs" />
     <Compile Include="LiveScript\ContentType\LiveScriptContentTypeDefinition.cs" />
+    <Compile Include="RazorZen\Classify\RazorZenClassificationTypes.cs" />
+    <Compile Include="RazorZen\Classify\RazorZenClassifier.cs" />
+    <Compile Include="RazorZen\Classify\RazorZenClassifierProvider.cs" />
+    <Compile Include="RazorZen\Commands\RazorZenCreationListener.cs" />
+    <Compile Include="RazorZen\ContentType\RazorZenContentTypeDefinition.cs" />
+    <Compile Include="RazorZen\Converter\RazorZenConverter.cs" />
+    <Compile Include="RazorZen\Margin\RazorZenMargin.cs" />
     <Compile Include="SCSS\Commands\ScssCreationListener.cs" />
     <Compile Include="SCSS\Commands\ScssExtractMixinCommandTarget.cs" />
     <Compile Include="SCSS\Commands\ScssExtractVariableCommandTarget.cs" />
@@ -435,6 +442,7 @@
     <Compile Include="Shared\Helpers\CssSourceMap.cs" />
     <Compile Include="Shared\Helpers\Base64Vlq.cs" />
     <Compile Include="Shared\Margins\CssTextViewMargin.cs" />
+    <Compile Include="StringExtention.cs" />
     <Compile Include="SweetJs\ContentType\SweetJsContentTypeDefinition.cs" />
     <Compile Include="RobotsTxt\Classify\RobotsTxtClassificationTypes.cs" />
     <Compile Include="RobotsTxt\Classify\RobotsTxtClassifier.cs" />


### PR DESCRIPTION
Hello
First: Thanks for the good work. 
# Summary
This pull request add a new function to HTML and RazorHTML files named “Show Zen representation”. 
The basic idea is that zen coding is not only easy to write it is also easy to read.
# What's inside

- A naive converter from HTML/RazorHTML to a zen/RazorZen like representation
- Basic syntax highlighting for zen/RazorZen
- A View in the HTML/RazorHTML Editor with the converted code, the vertical/horizontal scrolling and zooming in the viewport is synchronized.

# About the idea
The big idea is to improve the html editing experience to make it faster and easier. In the end, I would imagine that you could switch between two views. In one, you can edit the HTML code normally. In the other, you can write and read the code faster. 
For that, I have built this prototype. For me, the Zen view is useful. But, the effort to implement a proper converter and Syntax Highlighter is too big for me. In addition, since I have no practical experience with the implementation of those.
However, I want to share my version with you, you can do with it whatever you want. I think you are closer to the community and know better what might be useful for them.
I would be happy to see a version of it sometime in Web Essentials.
