### PR TITLE
Package: Updates MSBuild task to fix PathTooLong

### DIFF
--- a/EditorExtensions/Resources/server/services/srv-less.js
+++ b/EditorExtensions/Resources/server/services/srv-less.js
@@ -13,10 +13,10 @@ var handleLess = function (writer, params) {
                 SourceFileName: params.sourceFileName,
                 TargetFileName: params.targetFileName,
                 MapFileName: params.mapFileName,
-                Remarks: "LESS: Error reading input file.",
+                Remarks: "Less: Error reading input file.",
                 Details: err,
                 Errors: [{
-                    Message: "LESS" + err,
+                    Message: "Less" + err,
                     FileName: params.sourceFileName
                 }]
             }));
@@ -60,10 +60,10 @@ var handleLess = function (writer, params) {
                             SourceFileName: params.sourceFileName,
                             TargetFileName: params.targetFileName,
                             MapFileName: params.mapFileName,
-                            Remarks: "LESS: " + autoprefixedOutput.Remarks,
+                            Remarks: "Less: " + autoprefixedOutput.Remarks,
                             Details: autoprefixedOutput.Remarks,
                             Errors: [{
-                                Message: "LESS: " + autoprefixedOutput.Remarks,
+                                Message: "Less: " + autoprefixedOutput.Remarks,
                                 FileName: params.sourceFileName
                             }]
                         }));
@@ -121,12 +121,12 @@ var handleLess = function (writer, params) {
                     SourceFileName: params.sourceFileName,
                     TargetFileName: params.targetFileName,
                     MapFileName: params.mapFileName,
-                    Remarks: "LESS: Error parsing input file.",
+                    Remarks: "Less: Error parsing input file.",
                     Details: error.message,
                     Errors: [{
                         Line: error.line,
                         Column: error.column,
-                        Message: "LESS: " + error.message,
+                        Message: "Less: " + error.message,
                         FileName: error.filename
                     }]
                 }));

--- a/EditorExtensions/Resources/server/services/srv-rubyscss.js
+++ b/EditorExtensions/Resources/server/services/srv-rubyscss.js
@@ -86,10 +86,10 @@ var handleSass = function (writer, params) {
                             SourceFileName: params.sourceFileName,
                             TargetFileName: params.targetFileName,
                             MapFileName: params.mapFileName,
-                            Remarks: "SASS: " + autoprefixedOutput.Remarks,
+                            Remarks: "Sass: " + autoprefixedOutput.Remarks,
                             Details: autoprefixedOutput.Remarks,
                             Errors: [{
-                                Message: "SASS: " + autoprefixedOutput.Remarks,
+                                Message: "Sass: " + autoprefixedOutput.Remarks,
                                 FileName: params.sourceFileName
                             }]
                         }));
@@ -152,13 +152,13 @@ var handleSass = function (writer, params) {
                     SourceFileName: params.sourceFileName,
                     TargetFileName: params.targetFileName,
                     MapFileName: params.mapFileName,
-                    Remarks: "SASS: An error has occured while processing your request.",
+                    Remarks: "Sass: An error has occured while processing your request.",
                     Details: result.message,
                     Errors: [{
                         Line: result.line,
-                        Message: "SASS: " + result.message,
+                        Message: "Sass: " + result.message,
                         FileName: result.fileName,
-                        FullMessage: "SASS" + result.message
+                        FullMessage: "Sass" + result.message
                     }]
                 }));
                 writer.end();

--- a/EditorExtensions/Resources/server/services/srv-scss.js
+++ b/EditorExtensions/Resources/server/services/srv-scss.js
@@ -4,93 +4,25 @@ var sass = require("node-sass"),
 //#endregion
 
 //#region Handler
-var handleSass = function (writer, params) {
-    sass.render({
+var handleSass = function(writer, params) {
+    var options = {
         file: params.sourceFileName,
         outFile: params.targetFileName,
         includePaths: [path.dirname(params.sourceFileName)],
         precision: parseInt(params.precision, 10),
         outputStyle: params.outputStyle,
         sourceMap: params.mapFileName,
-        omitSourceMapUrl: params.sourceMapURL === undefined,
-        success: function (result) {
-            var css = result.css;
-            var map = result.map;
+        omitSourceMapUrl: params.sourceMapURL === undefined
+    };
 
-            if (params.autoprefixer !== undefined) {
-                var autoprefixedOutput = require("./srv-autoprefixer")
-                                        .processAutoprefixer(css, map, params.autoprefixerBrowsers,
-                                                             params.targetFileName, params.targetFileName);
-
-                if (!autoprefixedOutput.Success) {
-                    writer.write(JSON.stringify({
-                        Success: false,
-                        SourceFileName: params.sourceFileName,
-                        TargetFileName: params.targetFileName,
-                        MapFileName: params.mapFileName,
-                        Remarks: "SASS: " + autoprefixedOutput.Remarks,
-                        Details: autoprefixedOutput.Remarks,
-                        Errors: [{
-                            Message: "SASS: " + autoprefixedOutput.Remarks,
-                            FileName: params.sourceFileName
-                        }]
-                    }));
-                    writer.end();
-                    return;
-                }
-
-                css = autoprefixedOutput.css;
-                map = autoprefixedOutput.map;
-            }
-
-            if (params.rtlcss !== undefined) {
-                var rtlTargetWithoutExtension = params.targetFileName.substr(0, params.targetFileName.lastIndexOf("."));
-                var rtlTargetFileName = rtlTargetWithoutExtension + ".rtl.css";
-                var rtlMapFileName = rtlTargetFileName + ".map";
-                var rtlResult = require("./srv-rtlcss")
-                               .processRtlCSS(css, map, params.targetFileName, rtlTargetFileName);
-
-                if (rtlResult.Success) {
-                    writer.write(JSON.stringify({
-                        Success: true,
-                        SourceFileName: params.sourceFileName,
-                        TargetFileName: params.targetFileName,
-                        MapFileName: params.mapFileName,
-                        RtlSourceFileName: params.targetFileName,
-                        RtlTargetFileName: rtlTargetFileName,
-                        RtlMapFileName: rtlMapFileName,
-                        Remarks: "Successful!",
-                        Content: css,
-                        Map: JSON.stringify(map),
-                        RtlContent: rtlResult.css,
-                        RtlMap: JSON.stringify(rtlResult.map)
-                    }));
-
-                    writer.end();
-                } else {
-                    throw new Error("Error while processing RTLCSS");
-                }
-            } else {
-                writer.write(JSON.stringify({
-                    Success: true,
-                    SourceFileName: params.sourceFileName,
-                    TargetFileName: params.targetFileName,
-                    MapFileName: params.mapFileName,
-                    Remarks: "Successful!",
-                    Content: css,
-                    Map: JSON.stringify(map)
-                }));
-            }
-
-            writer.end();
-        },
-        error: function (error) {
+    sass.render(options, function(error, result) {
+        if (error) {
             writer.write(JSON.stringify({
                 Success: false,
                 SourceFileName: params.sourceFileName,
                 TargetFileName: params.targetFileName,
                 MapFileName: params.mapFileName,
-                Remarks: "SASS: An error has occured while processing your request.",
+                Remarks: "Sass: An error has occured while processing your request.",
                 Details: error.message,
                 Errors: [{
                     Line: error.line,
@@ -102,6 +34,76 @@ var handleSass = function (writer, params) {
             }));
             writer.end();
         }
+
+        var css = result.css.toString();
+        var map = result.map.toString();
+
+        if (params.autoprefixer !== undefined) {
+            var autoprefixedOutput = require("./srv-autoprefixer")
+                                    .processAutoprefixer(css, map, params.autoprefixerBrowsers,
+                                                         params.targetFileName, params.targetFileName);
+
+            if (!autoprefixedOutput.Success) {
+                writer.write(JSON.stringify({
+                    Success: false,
+                    SourceFileName: params.sourceFileName,
+                    TargetFileName: params.targetFileName,
+                    MapFileName: params.mapFileName,
+                    Remarks: "Sass: " + autoprefixedOutput.Remarks,
+                    Details: autoprefixedOutput.Remarks,
+                    Errors: [{
+                        Message: "Sass: " + autoprefixedOutput.Remarks,
+                        FileName: params.sourceFileName
+                    }]
+                }));
+                writer.end();
+                return;
+            }
+
+            css = autoprefixedOutput.css;
+            map = autoprefixedOutput.map;
+        }
+
+        if (params.rtlcss !== undefined) {
+            var rtlTargetWithoutExtension = params.targetFileName.substr(0, params.targetFileName.lastIndexOf("."));
+            var rtlTargetFileName = rtlTargetWithoutExtension + ".rtl.css";
+            var rtlMapFileName = rtlTargetFileName + ".map";
+            var rtlResult = require("./srv-rtlcss")
+                           .processRtlCSS(css, map, params.targetFileName, rtlTargetFileName);
+
+            if (rtlResult.Success) {
+                writer.write(JSON.stringify({
+                    Success: true,
+                    SourceFileName: params.sourceFileName,
+                    TargetFileName: params.targetFileName,
+                    MapFileName: params.mapFileName,
+                    RtlSourceFileName: params.targetFileName,
+                    RtlTargetFileName: rtlTargetFileName,
+                    RtlMapFileName: rtlMapFileName,
+                    Remarks: "Successful!",
+                    Content: css,
+                    Map: JSON.stringify(map),
+                    RtlContent: rtlResult.css,
+                    RtlMap: JSON.stringify(rtlResult.map)
+                }));
+
+                writer.end();
+            } else {
+                throw new Error("Error while processing RTLCSS");
+            }
+        } else {
+            writer.write(JSON.stringify({
+                Success: true,
+                SourceFileName: params.sourceFileName,
+                TargetFileName: params.targetFileName,
+                MapFileName: params.mapFileName,
+                Remarks: "Successful!",
+                Content: css,
+                Map: JSON.stringify(map)
+            }));
+        }
+
+        writer.end();
     });
 };
 //#endregion

--- a/EditorExtensions/WebEssentials2013.csproj
+++ b/EditorExtensions/WebEssentials2013.csproj
@@ -97,13 +97,13 @@
     <DeployExtension>False</DeployExtension>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AjaxMin, Version=5.12.5436.22729, Culture=neutral, PublicKeyToken=21ef50ce11b5d80f, processorArchitecture=MSIL">
+    <Reference Include="AjaxMin, Version=5.14.5506.26202, Culture=neutral, PublicKeyToken=21ef50ce11b5d80f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\AjaxMin.5.12.5436.22734\lib\net40\AjaxMin.dll</HintPath>
+      <HintPath>..\packages\AjaxMin.5.14.5506.26202\lib\net40\AjaxMin.dll</HintPath>
     </Reference>
     <Reference Include="CommonMark, Version=0.1.0.0, Culture=neutral, PublicKeyToken=001ef8810438905d, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\CommonMark.NET.0.8.0\lib\net45\CommonMark.dll</HintPath>
+      <HintPath>..\packages\CommonMark.NET.0.8.5\lib\net45\CommonMark.dll</HintPath>
     </Reference>
     <Reference Include="ConfOxide, Version=1.4.0.0, Culture=neutral, PublicKeyToken=934faed64f82030e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -229,8 +229,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="WebMarkupMin.Core">
-      <HintPath>..\packages\WebMarkupMin.Core.0.9.7\lib\net40\WebMarkupMin.Core.dll</HintPath>
-      <HintPath>..\packages\WebMarkupMin.Core.0.9.8\lib\net40\WebMarkupMin.Core.dll</HintPath>
+      <HintPath>..\packages\WebMarkupMin.Core.0.9.11\lib\net40\WebMarkupMin.Core.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="ZenCoding, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -1039,41 +1038,31 @@
     <Copy SourceFiles="@(NodeServerSource)" DestinationFolder="$(MSBuildProjectDirectory)\Resources\nodejs\tools\server\%(RecursiveDir)" SkipUnchangedFiles="true" />
     <!-- Include newly downloaded files now.. -->
     <ItemGroup>
-      <Content Include="Resources\nodejs\tools\**">
-        <IncludeInVSIX>true</IncludeInVSIX>
-      </Content>
       <!-- Exclude LESS & SASS because they have too many extra files; use a whitelist instead -->
-      <!--
-      -->
+
       <!-- Mocha comes from some package that forgot about "devDependencies"; Jade comes from Mocha -->
-      <!--
+
       <Content Include="Resources\nodejs\tools\**" Exclude="&#xD;&#xA; **\node-sass\**; **\less\**; &#xD;&#xA;               **\mocha\**; **\jade\**; &#xD;&#xA;               **\*.md; **\*.markdown; **\*.html; **\*.txt; **\LICENSE; **\README; **\CHANGELOG; **\CNAME; **\*.old; **\*.patch; **\*.ico; &#xD;&#xA;               **\*.json; **\.*; **\Makefile.*; **\Rakefile; **\*.yml; &#xD;&#xA;               **\test.*; **\generate-*; &#xD;&#xA;               **\*.min.js; **\*-min.js; &#xD;&#xA;               **\media\**; **\images\**; **\man\**; &#xD;&#xA;               **\.bin\**; **\benchmark\**; **\build\**; **\scripts\**; &#xD;&#xA;               **\vendor\**; &#xD;&#xA;               **\test\**; **\tst\**; **\tests\**; **\testing\**; &#xD;&#xA;               **\examples\**; **\example\**; **\tools\**\tools\**">
         <IncludeInVSIX>true</IncludeInVSIX>
       </Content>
-      <Content Include="Resources\nodejs\tools\node_modules\node-sass\index.js; Resources\nodejs\tools\node_modules\node-sass\bin\node-sass; Resources\nodejs\tools\node_modules\node-sass\lib\**; Resources\nodejs\tools\node_modules\node-sass\vendor\win32-ia32\**; Resources\nodejs\tools\node_modules\tslint\**; Resources\nodejs\tools\node_modules\jscs\**; Resources\nodejs\tools\node_modules\coffeelint\**;    Resources\nodejs\tools\node_modules\rtlcss\lib\**;    Resources\nodejs\tools\node_modules\rtlcss\bin\rtlcss.js;">
+      <Content Include="Resources\nodejs\tools\node_modules\node-sass\bin\node-sass; Resources\nodejs\tools\node_modules\node-sass\lib\**; Resources\nodejs\tools\node_modules\node-sass\vendor\**; Resources\nodejs\tools\node_modules\tslint\**; Resources\nodejs\tools\node_modules\jscs\**; Resources\nodejs\tools\node_modules\coffeelint\**;    Resources\nodejs\tools\node_modules\rtlcss\lib\**;    Resources\nodejs\tools\node_modules\rtlcss\bin\rtlcss.js;">
         <IncludeInVSIX>true</IncludeInVSIX>
       </Content>
       <Content Include="Resources\nodejs\tools\node_modules\less\index.js; Resources\nodejs\tools\node_modules\less\lib\**; Resources\nodejs\tools\node_modules\less\bin\**">
         <IncludeInVSIX>true</IncludeInVSIX>
       </Content>
-      -->
-      <!-- Explicit inclusions for CSON -->
-      <!--
-      <Content Include="Resources\nodejs\tools\node_modules\cson\package.json; Resources\nodejs\tools\node_modules\cson\out\**; Resources\nodejs\tools\node_modules\js2coffee\package.json;">
-        <IncludeInVSIX>true</IncludeInVSIX>
-      </Content>
-      -->
+
       <!-- Explicitly include JSON files that are actually needed at runtime -->
-      <!--
-      <Content Include="Resources\nodejs\tools\node_modules\htmlparser2\lib\entities\**; Resources\nodejs\tools\node_modules\jshint\package.json; Resources\nodejs\tools\node_modules\node-sass\package.json; Resources\nodejs\tools\node_modules\less\package.json; Resources\nodejs\tools\node_modules\resolve\lib\core.json; Resources\nodejs\tools\node_modules\escodegen\package.json;  Resources\nodejs\tools\node_modules\caniuse-db\**\*.json;">
+
+      <Content Include="Resources\nodejs\tools\node_modules\htmlparser2\lib\entities\**; Resources\nodejs\tools\node_modules\cson\package.json; Resources\nodejs\tools\node_modules\jshint\package.json; Resources\nodejs\tools\node_modules\node-sass\package.json; Resources\nodejs\tools\node_modules\less\package.json; Resources\nodejs\tools\node_modules\resolve\lib\core.json; Resources\nodejs\tools\node_modules\escodegen\package.json;  Resources\nodejs\tools\node_modules\caniuse-db\**\*.json;">
         <IncludeInVSIX>true</IncludeInVSIX>
       </Content>
-      -->
+
       <!-- Explicitly include files that are needed for JsHint -->
-      <!--
-      <Content Include="Resources\nodejs\tools\node_modules\entities\maps\**; Resources\nodejs\tools\node_modules\shelljs\src\test.js;">
+
+      <Content Include="Resources\nodejs\tools\node_modules\entities\maps\**; Resources\nodejs\tools\node_modules\shelljs\src\**;">
         <IncludeInVSIX>true</IncludeInVSIX>
-      </Content>-->
+      </Content>
     </ItemGroup>
   </Target>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/EditorExtensions/packages.config
+++ b/EditorExtensions/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AjaxMin" version="5.12.5436.22734" targetFramework="net451" />
-  <package id="CommonMark.NET" version="0.8.0" targetFramework="net451" />
-  <package id="ConfOxide" version="1.4.0.0" targetFramework="net451" />
+  <package id="AjaxMin" version="5.14.5506.26202" targetFramework="net451" />
+  <package id="CommonMark.NET" version="0.8.5" targetFramework="net451" />
+  <package id="ConfOxide" version="1.4.1" targetFramework="net451" />
   <package id="Minimatch" version="1.1.0" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net451" />
-  <package id="Pri.LongPath" version="1.2.2" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+  <package id="Pri.LongPath" version="1.3.2" targetFramework="net451" />
   <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net451" />
-  <package id="WebMarkupMin.Core" version="0.9.8" targetFramework="net451" />
+  <package id="WebMarkupMin.Core" version="0.9.11" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
* Downloads lastest npm matching with node.js
  latest stable release. (solution inspired by
  [nvmw](https://github.com/hakobera/nvmw)).
* Updates Sass service to comply with v3 changes.
* Updates Nuget packages.

@madskristensen, someone commented out the explicit inclusions in `csproj` file. We will need to test it once we get it to build. It still throws error with final routine, when copying files to packages. The `PreBuildTask` is executing successfully though. @SLaks, some packages (like `IcedCoffeeScript`) are not flattened. They still have `node_modules` subdirectory. Any ideas what is going wrong?