### PR TITLE
Correct Twitter card type. Fixes #1807

### DIFF
--- a/EditorExtensions/HTML/Completion/TwitterCardCompletion.cs
+++ b/EditorExtensions/HTML/Completion/TwitterCardCompletion.cs
@@ -14,7 +14,7 @@ namespace MadsKristensen.EditorExtensions.Html
         public TwitterCardCompletion()
             : base(new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase)
             {
-                { "twitter:card",  Values("app", "gallery", "photo", "player", "product", "summary", "summary_large-image") }
+                { "twitter:card",  Values("app", "gallery", "photo", "player", "product", "summary", "summary_large_image") }
             }) { }
     }
 }


### PR DESCRIPTION
This PR fixes a little bug in code intellisense - by default (and before this fix) WE2013 inserts invalid key value for Twitter's summary card preventing validation:
https://dev.twitter.com/cards/types/summary-large-image
The correct markup for this Twitter card type should be:
```html
<meta name="twitter:card" content="summary_large_image">
```

This commit fixes a typo in Twitter Card summary with large image
type key value. Having incorrect value here would prevent Twitter Card
from being validated on submission to Twitter for white-listing

Thanks!