### PR TITLE
Markdown: Add global CSS setting.

### DIFF
--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -699,11 +699,19 @@ namespace MadsKristensen.EditorExtensions.Settings
 
     public sealed class MarkdownSettings : SettingsBase<MarkdownSettings>, ICompilerInvocationSettings, IMarginSettings
     {
+        #region Editor
         [Category("Editor")]
         [DisplayName("Show preview pane")]
         [Description("Show a preview pane containing the rendered output in the editor.")]
         [DefaultValue(true)]
         public bool ShowPreviewPane { get; set; }
+
+        [Category("Editor")]
+        [DisplayName("Global CSS for Preview Pane")]
+        [Description("This CSS file will be applied to the preview pane so long as it's path is valid and there's no solution level custom css. To add a solution level CSS file, add a file with the filename ‘WE-Markdown.css’ in your solutions root directory or in a projects root directory. (Please note after setting this change, you'll need to close and reopen all markdown files)")]
+        [DefaultValue(null)]
+        public string GlobalPreviewCSSFile { get; set; }
+        #endregion
 
         #region Compilation
 


### PR DESCRIPTION
Created a settings option to specify the location of a global CSS file that will be applied to the markdown preview. If a solution level or project level file is found, that file will override this global file.

This is very similar to pull request [#1469](https://github.com/madskristensen/WebEssentials2013/pull/1469) but should be an easier merge as it was just forked this morning.

One thing to note, I hope the language I used in the settings dialog (for both the setting name and setting description) is sufficient. I'm not the greatest wordsmith out there.