### PR TITLE
Fix Pre-build task (fixes #1452)

### DIFF
--- a/BuildTasks/BuildTasks.csproj
+++ b/BuildTasks/BuildTasks.csproj
@@ -37,6 +37,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\MSBuild\12.0\Bin\Microsoft.Build.Utilities.v12.0.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1-beta3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Pri.LongPath, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Pri.LongPath.2.0.0-beta\lib\net45\Pri.LongPath.dll</HintPath>
       <Private>True</Private>
@@ -49,7 +53,6 @@
       <HintPath>..\packages\System.IO.Compression.ZipFile.4.0.0-beta-22816\lib\net45\System.IO.Compression.ZipFile.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />

--- a/BuildTasks/BuildTasks.csproj
+++ b/BuildTasks/BuildTasks.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{929EBBB6-004E-45C6-91AE-EE495540D2B8}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>WebEssentials.BuildTasks</RootNamespace>
+    <AssemblyName>BuildTasks</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Build.Framework">
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\MSBuild\12.0\Bin\Microsoft.Build.Framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Build.Utilities.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\MSBuild\12.0\Bin\Microsoft.Build.Utilities.v12.0.dll</HintPath>
+    </Reference>
+    <Reference Include="Pri.LongPath, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Pri.LongPath.2.0.0-beta\lib\net45\Pri.LongPath.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.IO.Compression.ZipFile, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.ZipFile.4.0.0-beta-22816\lib\net45\System.IO.Compression.ZipFile.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="NodeInstaller.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/BuildTasks/NodeInstaller.cs
+++ b/BuildTasks/NodeInstaller.cs
@@ -10,8 +10,8 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Microsoft.Build.Framework;
+using Newtonsoft.Json;
 using Pri.LongPath;
 using IO = System.IO;
 
@@ -133,22 +133,20 @@ namespace WebEssentials.BuildTasks
         private void CleanPath(string path)
         {
             Log.LogMessage(MessageImportance.High, "Cleaning extra files from " + path + "...");
+            int count = 0;
             foreach (string pattern in toRemove)
             {
                 string[] dirs = Directory.GetDirectories(path, pattern, IO.SearchOption.AllDirectories);
                 foreach (string dir in dirs)
-                {
-                    Log.LogMessage(MessageImportance.Low, "Removing " + dir + "...");
                     Directory.Delete(dir, true);
-                }
+                count += dirs.Length;
 
                 string[] files = Directory.GetFiles(path, pattern, IO.SearchOption.AllDirectories);
                 foreach (string file in files)
-                {
-                    Log.LogMessage(MessageImportance.Low, "Removing " + file + "...");
                     File.Delete(file);
-                }
+                count += files.Length;
             }
+            Log.LogMessage(MessageImportance.High, "Deleted " + count+ " items");
         }
 
         Task DownloadNodeAsync()

--- a/BuildTasks/NodeInstaller.cs
+++ b/BuildTasks/NodeInstaller.cs
@@ -129,20 +129,20 @@ namespace WebEssentials.BuildTasks
 
         private void CleanPath(string path)
         {
-            Log.LogMessage(MessageImportance.High, "Working on " + path + "...");
+            Log.LogMessage(MessageImportance.High, "Cleaning extra files from " + path + "...");
             foreach (string pattern in toRemove)
             {
                 string[] dirs = Directory.GetDirectories(path, pattern, IO.SearchOption.AllDirectories);
                 foreach (string dir in dirs)
                 {
-                    Log.LogMessage(MessageImportance.High, "Removing " + dir + "...");
+                    Log.LogMessage(MessageImportance.Low, "Removing " + dir + "...");
                     Directory.Delete(dir, true);
                 }
 
                 string[] files = Directory.GetFiles(path, pattern, IO.SearchOption.AllDirectories);
                 foreach (string file in files)
                 {
-                    Log.LogMessage(MessageImportance.High, "Removing " + file + "...");
+                    Log.LogMessage(MessageImportance.Low, "Removing " + file + "...");
                     File.Delete(file);
                 }
             }
@@ -322,10 +322,21 @@ namespace WebEssentials.BuildTasks
                         }
                     }
 
-                    string targetDir = Path.Combine(baseDir.FullName, "node_modules", module.Name);
-                    if (!Directory.Exists(targetDir))
+                    if (module.Name == ".bin")
+                        continue;
+
+                    var intermediatePath = Path.GetFullPath(baseDir.FullName).TrimEnd('\\');
+                    foreach (var part in module.FullName.Substring(intermediatePath.Length).Split(new[] { @"\node_modules\" }, StringSplitOptions.None))
+                    {
+                        intermediatePath = (intermediatePath + "\\" + part).TrimEnd('\\');
+                        if (intermediatePath.EndsWith("node_modules"))
+                            continue;
+                        string targetDir = Path.Combine(intermediatePath, "node_modules", module.Name);
+                        if (Directory.Exists(targetDir))
+                            continue;
                         module.MoveTo(targetDir);
-                    else if (module.Name != ".bin")
+                    }
+                    if (module.Exists)
                         Log.LogMessage(MessageImportance.High, "Not collapsing conflicting module " + module.FullName);
                 }
 

--- a/BuildTasks/NodeInstaller.cs
+++ b/BuildTasks/NodeInstaller.cs
@@ -10,7 +10,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web.Helpers;
+using Newtonsoft.Json;
 using Microsoft.Build.Framework;
 using Pri.LongPath;
 using IO = System.IO;
@@ -168,7 +168,7 @@ namespace WebEssentials.BuildTasks
 
             await WebClientDoAsync(wc => wc.DownloadFileTaskAsync("https://raw.githubusercontent.com/joyent/node/master/deps/npm/package.json", @"resources\nodejs\package.json"));
 
-            dynamic nodeInfo = Json.Decode(File.ReadAllText(@"resources\nodejs\package.json"));
+            dynamic nodeInfo = JsonConvert.DeserializeObject(File.ReadAllText(@"resources\nodejs\package.json"));
             string npmVersion = nodeInfo.version;
 
             string npmUrl = string.Format(CultureInfo.CurrentCulture, "https://github.com/npm/npm/archive/v{0}.zip", npmVersion);
@@ -308,7 +308,7 @@ namespace WebEssentials.BuildTasks
                     // can find it without package.json.
                     if (module.Name != ".bin" && !File.Exists(Path.Combine(module.FullName, "index.js")))
                     {
-                        dynamic package = Json.Decode(File.ReadAllText(module.FullName + "\\package.json"));
+                        dynamic package = JsonConvert.DeserializeObject(File.ReadAllText(module.FullName + "\\package.json"));
                         string main = package.main;
 
                         if (!string.IsNullOrEmpty(main))
@@ -317,7 +317,7 @@ namespace WebEssentials.BuildTasks
                                 main = "./" + main;
                             File.WriteAllText(
                                 Path.Combine(module.FullName, "index.js"),
-                                "module.exports = require(" + Json.Encode(main) + ");"
+                                "module.exports = require(" + JsonConvert.ToString(main) + ");"
                             );
                         }
                     }

--- a/BuildTasks/Properties/AssemblyInfo.cs
+++ b/BuildTasks/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("BuildTasks")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("BuildTasks")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("929ebbb6-004e-45c6-91ae-ee495540d2b8")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/BuildTasks/packages.config
+++ b/BuildTasks/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="7.0.1-beta3" targetFramework="net45" userInstalled="true" />
   <package id="Pri.LongPath" version="2.0.0-beta" targetFramework="net45" userInstalled="true" />
   <package id="System.IO" version="4.0.10-beta-22816" targetFramework="net45" userInstalled="true" />
   <package id="System.IO.Compression" version="4.0.0-beta-22816" targetFramework="net45" userInstalled="true" />

--- a/BuildTasks/packages.config
+++ b/BuildTasks/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Pri.LongPath" version="2.0.0-beta" targetFramework="net45" userInstalled="true" />
+  <package id="System.IO" version="4.0.10-beta-22816" targetFramework="net45" userInstalled="true" />
+  <package id="System.IO.Compression" version="4.0.0-beta-22816" targetFramework="net45" userInstalled="true" />
+  <package id="System.IO.Compression.ZipFile" version="4.0.0-beta-22816" targetFramework="net45" userInstalled="true" />
+  <package id="System.Runtime" version="4.0.20-beta-22816" targetFramework="net45" userInstalled="true" />
+  <package id="System.Text.Encoding" version="4.0.10-beta-22816" targetFramework="net45" userInstalled="true" />
+  <package id="System.Threading.Tasks" version="4.0.10-beta-22816" targetFramework="net45" userInstalled="true" />
+</packages>

--- a/EditorExtensions/WebEssentials2013.csproj
+++ b/EditorExtensions/WebEssentials2013.csproj
@@ -10,7 +10,6 @@
     <TargetDevEnvDir>$(VSINSTALLDIR)\Common7\IDE</TargetDevEnvDir>
     <VSSDKTargetsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(TargetVisualStudioVersion)\VSSDK</VSSDKTargetsPath>
     <VSSDKTargetPlatformRegRoot>Software\Microsoft\VisualStudio\$(TargetVisualStudioVersion)</VSSDKTargetPlatformRegRoot>
-
     <ExtensionsDeploymentSubPath Condition="'$(ExtensionsDeploymentSubPath)' == ''">Microsoft\VisualStudio\$(TargetVisualStudioVersion)$(VSSDKTargetPlatformRegRootSuffix)\Extensions\</ExtensionsDeploymentSubPath>
   </PropertyGroup>
   <PropertyGroup>
@@ -799,7 +798,6 @@
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <EmbeddedResource Include="BrowserLink\BrowserInfo\BrowserInfo.js" />
-    <None Include="PreBuildTask.cs" />
     <Content Include="Resources\Icons\Bundle.ico">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
@@ -1016,7 +1014,13 @@
       <SubType>Designer</SubType>
     </Page>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\BuildTasks\BuildTasks.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <Project>{929ebbb6-004e-45c6-91ae-ee495540d2b8}</Project>
+      <Name>BuildTasks</Name>
+    </ProjectReference>
+  </ItemGroup>
   <PropertyGroup>
     <UseCodebase>true</UseCodebase>
   </PropertyGroup>
@@ -1033,17 +1037,9 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <UsingTask TaskName="MadsKristensen.EditorExtensions.PreBuildTask" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll">
-    <Task>
-      <Reference Include="Microsoft.CSharp" />
-      <Reference Include="System.IO.Compression" />
-      <Reference Include="System.IO.Compression.FileSystem" />
-      <Reference Include="System.Web.Helpers" />
-      <Code Language="cs" Source="PreBuildTask.cs" />
-    </Task>
-  </UsingTask>
+  <UsingTask TaskName="WebEssentials.BuildTasks.NodeInstaller" AssemblyFile="$(SolutionDir)BuildTasks\bin\$(Configuration)\BuildTasks.dll" />
   <Target Name="BeforeBuild">
-    <MadsKristensen.EditorExtensions.PreBuildTask />
+    <WebEssentials.BuildTasks.NodeInstaller />
     <!-- Copy node.js server and services to tools -->
     <ItemGroup>
       <NodeServerSource Include="$(MSBuildProjectDirectory)\Resources\server\**\*.*" Exclude="$(MSBuildProjectDirectory)\Resources\server\.jshintrc" />

--- a/EditorExtensions/WebEssentials2013.csproj
+++ b/EditorExtensions/WebEssentials2013.csproj
@@ -1,9 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetVisualStudioVersion>12.0</TargetVisualStudioVersion>
+    <VSToolsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(TargetVisualStudioVersion)</VSToolsPath>
+    <VSINSTALLDIR>$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\SxS\VS7@$(TargetVisualStudioVersion))</VSINSTALLDIR>
+    <VSINSTALLDIR Condition="'$(VSINSTALLDIR)' == ''">$(registry:HKEY_CURRENT_USER\SOFTWARE\Microsoft\VisualStudio\SxS\VS7@12.0)</VSINSTALLDIR>
+    <VSINSTALLDIR Condition="'$(VSINSTALLDIR)' == ''">$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\SxS\VS7@12.0)</VSINSTALLDIR>
+    <VSINSTALLDIR Condition="'$(VSINSTALLDIR)' == ''">$(registry:HKEY_CURRENT_USER\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\SxS\VS7@12.0)</VSINSTALLDIR>
+    <TargetDevEnvDir>$(VSINSTALLDIR)\Common7\IDE</TargetDevEnvDir>
+    <VSSDKTargetsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(TargetVisualStudioVersion)\VSSDK</VSSDKTargetsPath>
+    <VSSDKTargetPlatformRegRoot>Software\Microsoft\VisualStudio\$(TargetVisualStudioVersion)</VSSDKTargetPlatformRegRoot>
+
+    <ExtensionsDeploymentSubPath Condition="'$(ExtensionsDeploymentSubPath)' == ''">Microsoft\VisualStudio\$(TargetVisualStudioVersion)$(VSSDKTargetPlatformRegRootSuffix)\Extensions\</ExtensionsDeploymentSubPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <!-- Necessary to open the project in any version of VS. -->
+    <MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
     <SccProjectName>
     </SccProjectName>
     <SccLocalPath>
@@ -33,7 +45,7 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <StartAction>Program</StartAction>
-    <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
+    <StartProgram>$(TargetDevEnvDir)\devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp</StartArguments>
     <ZipPackageCompressionLevel>Normal</ZipPackageCompressionLevel>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -128,11 +140,11 @@
     <Reference Include="Microsoft.Collections.Immutable, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.JSON.Core">
-      <HintPath>$(DevEnvDir)\Extensions\Microsoft\Web Tools\Languages\Microsoft.JSON.Core.dll</HintPath>
+      <HintPath>$(TargetDevEnvDir)\Extensions\Microsoft\Web Tools\Languages\Microsoft.JSON.Core.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.JSON.Editor">
-      <HintPath>$(DevEnvDir)\Extensions\Microsoft\Web Tools\Languages\Microsoft.JSON.Editor.dll</HintPath>
+      <HintPath>$(TargetDevEnvDir)\Extensions\Microsoft\Web Tools\Languages\Microsoft.JSON.Editor.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Practices.TransientFaultHandling.Core">
@@ -140,29 +152,29 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.JSLS, Version=12.0.0.0" />
     <Reference Include="Microsoft.VisualStudio.JSON.Package">
-      <HintPath>$(DevEnvDir)\Extensions\Microsoft\Web Tools\Languages\Microsoft.VisualStudio.JSON.Package.dll</HintPath>
+      <HintPath>$(TargetDevEnvDir)\Extensions\Microsoft\Web Tools\Languages\Microsoft.VisualStudio.JSON.Package.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Language.StandardClassification, Version=12.0.0.0" />
     <Reference Include="Microsoft.CSS.Core, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(DevEnvDir)\CommonExtensions\Microsoft\Web\Editor\Microsoft.CSS.Core.dll</HintPath>
+      <HintPath>$(TargetDevEnvDir)\CommonExtensions\Microsoft\Web\Editor\Microsoft.CSS.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSS.Editor, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(DevEnvDir)\CommonExtensions\Microsoft\Web\Editor\Microsoft.CSS.Editor.dll</HintPath>
+      <HintPath>$(TargetDevEnvDir)\CommonExtensions\Microsoft\Web\Editor\Microsoft.CSS.Editor.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Html.Core, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(DevEnvDir)\CommonExtensions\Microsoft\Web\Editor\Microsoft.Html.Core.dll</HintPath>
+      <HintPath>$(TargetDevEnvDir)\CommonExtensions\Microsoft\Web\Editor\Microsoft.Html.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Html.Editor, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(DevEnvDir)\CommonExtensions\Microsoft\Web\Editor\Microsoft.Html.Editor.dll</HintPath>
+      <HintPath>$(TargetDevEnvDir)\CommonExtensions\Microsoft\Web\Editor\Microsoft.Html.Editor.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.Internal, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Text.Internal.dll</HintPath>
+      <HintPath>$(TargetDevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Text.Internal.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop.12.0" />
     <Reference Include="Microsoft.VisualStudio.Html.Package" />
@@ -185,12 +197,12 @@
     <Reference Include="Microsoft.VisualStudio.Threading, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Web.BrowserLink.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Web.Extensions">
-      <HintPath>$(DevEnvDir)\Extensions\Microsoft\Web Tools\Languages\Microsoft.VisualStudio.Web.Extensions.dll</HintPath>
+      <HintPath>$(TargetDevEnvDir)\Extensions\Microsoft\Web Tools\Languages\Microsoft.VisualStudio.Web.Extensions.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Web.Core, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(DevEnvDir)\CommonExtensions\Microsoft\Web\Editor\Microsoft.Web.Core.dll</HintPath>
+      <HintPath>$(TargetDevEnvDir)\CommonExtensions\Microsoft\Web\Editor\Microsoft.Web.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Editor, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.OLE.Interop" />
@@ -203,7 +215,7 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0" />
     <Reference Include="Microsoft.Web.Editor, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(DevEnvDir)\CommonExtensions\Microsoft\Web\Editor\Microsoft.Web.Editor.dll</HintPath>
+      <HintPath>$(TargetDevEnvDir)\CommonExtensions\Microsoft\Web\Editor\Microsoft.Web.Editor.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/EditorExtensions/WebEssentials2013.csproj
+++ b/EditorExtensions/WebEssentials2013.csproj
@@ -2,15 +2,16 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
     <TargetVisualStudioVersion>12.0</TargetVisualStudioVersion>
+    
+    <!-- Including the specific version of the SDK targets will deploy to that version even when building a later version. -->
     <VSToolsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(TargetVisualStudioVersion)</VSToolsPath>
+    
+    <!-- However, we still need to calculate DevEnvDir by hand to locate referenced VS assemblies from the target version. -->
     <VSINSTALLDIR>$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\SxS\VS7@$(TargetVisualStudioVersion))</VSINSTALLDIR>
     <VSINSTALLDIR Condition="'$(VSINSTALLDIR)' == ''">$(registry:HKEY_CURRENT_USER\SOFTWARE\Microsoft\VisualStudio\SxS\VS7@12.0)</VSINSTALLDIR>
     <VSINSTALLDIR Condition="'$(VSINSTALLDIR)' == ''">$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\SxS\VS7@12.0)</VSINSTALLDIR>
     <VSINSTALLDIR Condition="'$(VSINSTALLDIR)' == ''">$(registry:HKEY_CURRENT_USER\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\SxS\VS7@12.0)</VSINSTALLDIR>
     <TargetDevEnvDir>$(VSINSTALLDIR)\Common7\IDE</TargetDevEnvDir>
-    <VSSDKTargetsPath>$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(TargetVisualStudioVersion)\VSSDK</VSSDKTargetsPath>
-    <VSSDKTargetPlatformRegRoot>Software\Microsoft\VisualStudio\$(TargetVisualStudioVersion)</VSSDKTargetPlatformRegRoot>
-    <ExtensionsDeploymentSubPath Condition="'$(ExtensionsDeploymentSubPath)' == ''">Microsoft\VisualStudio\$(TargetVisualStudioVersion)$(VSSDKTargetPlatformRegRootSuffix)\Extensions\</ExtensionsDeploymentSubPath>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Necessary to open the project in any version of VS. -->

--- a/WebEssentials2013.sln
+++ b/WebEssentials2013.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.22823.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{140A15DE-0F66-4377-BB52-BC24C7FC46E9}"
 	ProjectSection(SolutionItems) = preProject
@@ -17,16 +17,16 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		ZenCoding.dll = ZenCoding.dll
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebEssentials2013", "EditorExtensions\WebEssentials2013.csproj", "{10D05BC1-CDEE-4D14-B88F-F91C0BDC7861}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebEssentialsTests", "WebEssentialsTests\WebEssentialsTests.csproj", "{E05B0E57-CF56-4513-9D24-18B6EE7C3712}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{6A26D63B-3436-438D-8F27-C42E100B2254}"
 	ProjectSection(SolutionItems) = preProject
 		.nuget\NuGet.Config = .nuget\NuGet.Config
 		.nuget\NuGet.exe = .nuget\NuGet.exe
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebEssentials2013", "EditorExtensions\WebEssentials2013.csproj", "{10D05BC1-CDEE-4D14-B88F-F91C0BDC7861}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebEssentialsTests", "WebEssentialsTests\WebEssentialsTests.csproj", "{E05B0E57-CF56-4513-9D24-18B6EE7C3712}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/WebEssentials2013.sln
+++ b/WebEssentials2013.sln
@@ -28,6 +28,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebEssentials2013", "Editor
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebEssentialsTests", "WebEssentialsTests\WebEssentialsTests.csproj", "{E05B0E57-CF56-4513-9D24-18B6EE7C3712}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BuildTasks", "BuildTasks\BuildTasks.csproj", "{929EBBB6-004E-45C6-91AE-EE495540D2B8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,6 +44,10 @@ Global
 		{E05B0E57-CF56-4513-9D24-18B6EE7C3712}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E05B0E57-CF56-4513-9D24-18B6EE7C3712}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E05B0E57-CF56-4513-9D24-18B6EE7C3712}.Release|Any CPU.Build.0 = Release|Any CPU
+		{929EBBB6-004E-45C6-91AE-EE495540D2B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{929EBBB6-004E-45C6-91AE-EE495540D2B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{929EBBB6-004E-45C6-91AE-EE495540D2B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{929EBBB6-004E-45C6-91AE-EE495540D2B8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
 - Make solution open in VS2015 (still builds & deploys to 2013)
 - Separate pre-build task into its own project for better development & debugging
 - Permanently fix all path-too-long errors with a much more aggressive flattener
 - More aggressively remove duplicate module versions for a smaller VSIX

If you get build errors from `BuildTasks` that the file is in use, kill all MSBuild processes and try again.

We should probably make the prebuild task skip everything if the files are already up to date (perhaps update only once a week?)