### PR TITLE
Validation: Add a switch to disable SEO microdata validation

### DIFF
--- a/EditorExtensions/BrowserLink/BestPractices/BestPracticesBrowserLink.cs
+++ b/EditorExtensions/BrowserLink/BestPractices/BestPracticesBrowserLink.cs
@@ -60,6 +60,10 @@ namespace MadsKristensen.EditorExtensions
 
             if (rule != null)
             {
+                // Force/fake the success flag if a specific validation is disabled
+                if (id == "microdata" && !Settings.WESettings.Instance.Html.EnableMicrodataValidation)
+                    success = true;
+
                 CreateTask(id, rule, success);
                 ErrorList.Tasks.Clear();
 

--- a/EditorExtensions/BrowserLink/BestPractices/Rules/RulesFactory.cs
+++ b/EditorExtensions/BrowserLink/BestPractices/Rules/RulesFactory.cs
@@ -1,6 +1,4 @@
 ﻿
-using MadsKristensen.EditorExtensions.Settings;
-
 namespace MadsKristensen.EditorExtensions
 {
     public static class RulesFactory
@@ -14,9 +12,7 @@ namespace MadsKristensen.EditorExtensions
                 //case "favicon":
                 //    return new Favicon();
                 case "microdata":
-                    if (WESettings.Instance.Html.EnableSEOValidation)
-                        return new Microdata();
-                    break;
+                    return new Microdata();
                 case "description":
                     return new Description(data, extension);
                 case "viewport":

--- a/EditorExtensions/BrowserLink/BestPractices/Rules/RulesFactory.cs
+++ b/EditorExtensions/BrowserLink/BestPractices/Rules/RulesFactory.cs
@@ -1,4 +1,6 @@
 ﻿
+using MadsKristensen.EditorExtensions.Settings;
+
 namespace MadsKristensen.EditorExtensions
 {
     public static class RulesFactory
@@ -12,7 +14,9 @@ namespace MadsKristensen.EditorExtensions
                 //case "favicon":
                 //    return new Favicon();
                 case "microdata":
-                    return new Microdata();
+                    if (WESettings.Instance.Html.EnableSEOValidation)
+                        return new Microdata();
+                    break;
                 case "description":
                     return new Description(data, extension);
                 case "viewport":

--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -313,6 +313,16 @@ namespace MadsKristensen.EditorExtensions.Settings
         public string OutputDirectory { get; set; }
 
         #endregion
+
+        #region Validations
+
+        [Category("Validations")]
+        [DisplayName("Enable SEO validation")]
+        [Description("Enable or disable SEO validation for microdata. Microdata helps adding semantic meaning to a website.")]
+        [DefaultValue(true)]
+        public bool EnableSEOValidation { get; set; }
+
+        #endregion
     }
 
     public sealed class ImageDropFormat : SettingsBase<ImageDropFormat>

--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -317,10 +317,10 @@ namespace MadsKristensen.EditorExtensions.Settings
         #region Validations
 
         [Category("Validations")]
-        [DisplayName("Enable SEO validation")]
+        [DisplayName("Enable microdata validation")]
         [Description("Enable or disable SEO validation for microdata. Microdata helps adding semantic meaning to a website.")]
         [DefaultValue(true)]
-        public bool EnableSEOValidation { get; set; }
+        public bool EnableMicrodataValidation { get; set; }
 
         #endregion
     }


### PR DESCRIPTION
Add an option to disable the validation about microdata. 

![image](https://cloud.githubusercontent.com/assets/1680372/8223998/a23a8fd6-154d-11e5-9456-c0f8876791aa.png)

Turning this switch to false will remove this error message that can be useless for an intranet application per example.

    SEO: Use HTML5 microdata to add semantic meaning to the website.

This could fix #1878 

I will copy this modification to WE2015 if this PR is accepted.