### PR TITLE
SourceMap: Fixes for CSS source-map processing

### DIFF
--- a/EditorExtensions/Resources/server/services/srv-autoprefixer.js
+++ b/EditorExtensions/Resources/server/services/srv-autoprefixer.js
@@ -32,13 +32,10 @@ var processAutoprefixer = function (cssContent, mapContent, browsers, sourceFile
         to: targetFileName
     });
 
-    // Curate maps
-    mapContent = result.map.toJSON();
-
     return {
         Success: true,
         css: result.css,
-        map: mapContent
+        map: result.map
     };
 };
 //#endregion

--- a/EditorExtensions/Resources/server/services/srv-less.js
+++ b/EditorExtensions/Resources/server/services/srv-less.js
@@ -45,9 +45,7 @@ var handleLess = function (writer, params) {
         less.render(data, options)
             .then(function (output) {
                 css = output.css;
-
-                if (output.map)
-                    map = JSON.parse(output.map);
+                map = output.map;
 
                 if (params.autoprefixer !== undefined) {
                     var autoprefixedOutput = require("./srv-autoprefixer")
@@ -72,7 +70,7 @@ var handleLess = function (writer, params) {
                     }
 
                     css = autoprefixedOutput.css;
-                    map = autoprefixedOutput.map;
+                    map = JSON.stringify(autoprefixedOutput.map);
                 }
 
                 if (params.rtlcss !== undefined) {

--- a/EditorExtensions/Resources/server/services/srv-scss.js
+++ b/EditorExtensions/Resources/server/services/srv-scss.js
@@ -1,6 +1,6 @@
 //#region Imports
 var sass = require("node-sass"),
-    path = require("path")
+    path = require("path");
 //#endregion
 
 //#region Handler
@@ -61,7 +61,7 @@ var handleSass = function(writer, params) {
             }
 
             css = autoprefixedOutput.css;
-            map = autoprefixedOutput.map;
+            map = JSON.stringify(autoprefixedOutput.map);
         }
 
         if (params.rtlcss !== undefined) {
@@ -82,7 +82,7 @@ var handleSass = function(writer, params) {
                     RtlMapFileName: rtlMapFileName,
                     Remarks: "Successful!",
                     Content: css,
-                    Map: JSON.stringify(map),
+                    Map: map,
                     RtlContent: rtlResult.css,
                     RtlMap: JSON.stringify(rtlResult.map)
                 }));
@@ -99,7 +99,7 @@ var handleSass = function(writer, params) {
                 MapFileName: params.mapFileName,
                 Remarks: "Successful!",
                 Content: css,
-                Map: JSON.stringify(map)
+                Map: map
             }));
         }
 

--- a/EditorExtensions/WebEssentials2013.csproj
+++ b/EditorExtensions/WebEssentials2013.csproj
@@ -1060,7 +1060,7 @@
         <IncludeInVSIX>true</IncludeInVSIX>
       </Content>
       <!-- Explicitly include JSON files that are actually needed at runtime -->
-      <Content Include="Resources\nodejs\tools\node_modules\htmlparser2\lib\entities\**; Resources\nodejs\tools\node_modules\cson\package.json; Resources\nodejs\tools\node_modules\jshint\package.json; Resources\nodejs\tools\node_modules\node-sass\package.json; Resources\nodejs\tools\node_modules\less\package.json; Resources\nodejs\tools\node_modules\resolve\lib\core.json; Resources\nodejs\tools\node_modules\escodegen\package.json;  Resources\nodejs\tools\node_modules\caniuse-db\**\*.json;">
+      <Content Include="Resources\nodejs\tools\node_modules\htmlparser2\lib\entities\**; Resources\nodejs\tools\node_modules\cson\package.json; Resources\nodejs\tools\node_modules\jshint\package.json; Resources\nodejs\tools\node_modules\node-sass\package.json; Resources\nodejs\tools\node_modules\postcss\package.json; Resources\nodejs\tools\node_modules\less\package.json; Resources\nodejs\tools\node_modules\resolve\lib\core.json; Resources\nodejs\tools\node_modules\escodegen\package.json;  Resources\nodejs\tools\node_modules\caniuse-db\**\*.json;">
         <IncludeInVSIX>true</IncludeInVSIX>
       </Content>
       <!-- Explicitly include files that are needed for JsHint -->


### PR DESCRIPTION
* Removes fallback VLQ cure for sass since sass/libsass#324 is fixed.
* `.ToList()` to eagerly load VLQ maps. The subsequent `.Count()` was
  causing redundant processing of all mappings (which is pretty
  expensive).
* Autoprefix takes stringly maps and returns object for map. So we are
  strigifying returned map in Less and Sass.