### PR TITLE
CSS: Makes relative-paths disableable via setting

### DIFF
--- a/EditorExtensions/Resources/server/services/srv-less.js
+++ b/EditorExtensions/Resources/server/services/srv-less.js
@@ -30,7 +30,6 @@ var handleLess = function (writer, params) {
         var sourceDir = path.dirname(params.sourceFileName);
         var options = {
             filename: params.sourceFileName,
-            relativeUrls: true,
             paths: [sourceDir],
             sourceMap: {
                 sourceMapFullFilename: mapFileName,
@@ -70,7 +69,7 @@ var handleLess = function (writer, params) {
                     }
 
                     css = autoprefixedOutput.css;
-                    map = JSON.stringify(autoprefixedOutput.map);
+                    map = autoprefixedOutput.map;
                 }
 
                 if (params.rtlcss !== undefined) {

--- a/EditorExtensions/SCSS/Compilers/ScssCompiler.cs
+++ b/EditorExtensions/SCSS/Compilers/ScssCompiler.cs
@@ -1,12 +1,12 @@
 ﻿using System.ComponentModel.Composition;
 using System.Globalization;
+using System.IO;
 using System.Threading.Tasks;
 using System.Web;
 using MadsKristensen.EditorExtensions.RtlCss;
 using MadsKristensen.EditorExtensions.Settings;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Web.Editor;
-using System.IO;
 
 namespace MadsKristensen.EditorExtensions.Scss
 {

--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -604,7 +604,16 @@ namespace MadsKristensen.EditorExtensions.Settings
         }
     }
 
-    public sealed class LessSettings : ChainableCompilationSettings<LessSettings>
+    public abstract class CssChainableCompilationSettings<T> : ChainableCompilationSettings<T>, ICssChainableCompilerSettings where T : CssChainableCompilationSettings<T>
+    {
+        [Category("Compilation")]
+        [DisplayName("Adjust Relative Paths")]
+        [Description("Adjust relative paths in post-processing step. This option only works when \"Custom output directory\" is used.")]
+        [DefaultValue(true)]
+        public bool AdjustRelativePaths { get; set; }
+    }
+
+    public sealed class LessSettings : CssChainableCompilationSettings<LessSettings>
     {
         [Category("Compilation")]
         [DisplayName("Strict Math")]
@@ -613,9 +622,8 @@ namespace MadsKristensen.EditorExtensions.Settings
         public bool StrictMath { get; set; }
     }
 
-    public sealed class ScssSettings : ChainableCompilationSettings<ScssSettings>
+    public sealed class ScssSettings : CssChainableCompilationSettings<ScssSettings>
     {
-
         public enum OutputFormat
         {
             Expanded,
@@ -786,6 +794,11 @@ namespace MadsKristensen.EditorExtensions.Settings
     {
         bool EnableChainCompilation { get; }
         event EventHandler EnableChainCompilationChanged;
+    }
+
+    public interface ICssChainableCompilerSettings : IChainableCompilerSettings
+    {
+        bool AdjustRelativePaths { get; }
     }
 
     public interface IMinifierSettings

--- a/EditorExtensions/Shared/Compilers/CssCompilerBase.cs
+++ b/EditorExtensions/Shared/Compilers/CssCompilerBase.cs
@@ -13,6 +13,7 @@ namespace MadsKristensen.EditorExtensions
         {
             // If the caller wants us to renormalize URLs to a different filename, do so.
             if (targetFileName != null &&
+                WESettings.Instance.ForContentType<ICssChainableCompilerSettings>(Mef.GetContentType(ServiceName)).AdjustRelativePaths &&
                 Path.GetDirectoryName(targetFileName) != Path.GetDirectoryName(sourceFileName) &&
                 result.IndexOf("url(", StringComparison.OrdinalIgnoreCase) > 0)
             {


### PR DESCRIPTION
Fixes #1465, #1837 and some others.