### PR TITLE
Code: Path fixes for [Le/Sa]ss compilers

### DIFF
--- a/EditorExtensions/LESS/Compilers/LessCompiler.cs
+++ b/EditorExtensions/LESS/Compilers/LessCompiler.cs
@@ -33,6 +33,9 @@ namespace MadsKristensen.EditorExtensions.Less
             if (WESettings.Instance.Less.StrictMath)
                 parameters.Add("strictMath");
 
+            if (WESettings.Instance.Less.AdjustRelativePaths)
+                parameters.Add("relativeUrls");
+
             if (WESettings.Instance.Css.Autoprefix)
             {
                 parameters.Add("autoprefixer");

--- a/EditorExtensions/Resources/server/services/srv-less.js
+++ b/EditorExtensions/Resources/server/services/srv-less.js
@@ -31,6 +31,7 @@ var handleLess = function (writer, params) {
         var options = {
             filename: params.sourceFileName,
             paths: [sourceDir],
+            relativeUrls: params.relativeUrls !== undefined,
             sourceMap: {
                 sourceMapFullFilename: mapFileName,
                 sourceMapURL: params.sourceMapURL !== undefined ? path.basename(mapFileName) : null,

--- a/EditorExtensions/Shared/Compilers/CssCompilerBase.cs
+++ b/EditorExtensions/Shared/Compilers/CssCompilerBase.cs
@@ -1,44 +1,11 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Threading.Tasks;
-using MadsKristensen.EditorExtensions.Helpers;
 using MadsKristensen.EditorExtensions.Settings;
-using Microsoft.CSS.Core;
 
 namespace MadsKristensen.EditorExtensions
 {
     public abstract class CssCompilerBase : NodeExecutorBase
     {
-        protected override string PostProcessResult(string result, string targetFileName, string sourceFileName)
-        {
-            // If the caller wants us to renormalize URLs to a different filename, do so.
-            if (targetFileName != null &&
-                WESettings.Instance.ForContentType<ICssChainableCompilerSettings>(Mef.GetContentType(ServiceName)).AdjustRelativePaths &&
-                Path.GetDirectoryName(targetFileName) != Path.GetDirectoryName(sourceFileName) &&
-                result.IndexOf("url(", StringComparison.OrdinalIgnoreCase) > 0)
-            {
-                try
-                {
-                    result = CssUrlNormalizer.NormalizeUrls(
-                                   tree: new CssParser().Parse(result, true),
-                                   targetFile: targetFileName,
-                                   oldBasePath: sourceFileName);
-
-                    Logger.Log(ServiceName + ": " + Path.GetFileName(sourceFileName) + " compiled.");
-                }
-                catch (Exception ex)
-                {
-                    Logger.Log(ServiceName + ": An error occurred while normalizing generated paths in " + sourceFileName + "\r\n" + ex);
-                }
-            }
-            else
-            {
-                Logger.Log(ServiceName + ": " + Path.GetFileName(sourceFileName) + " compiled.");
-            }
-
-            return result;
-        }
-
         protected async override Task RtlVariantHandler(CompilerResult result)
         {
             if (!WESettings.Instance.Css.RtlCss || result.RtlTargetFileName == null)


### PR DESCRIPTION
* Passes user setting to Less compiler.
* Sass compiler does not provide the setting, so I have moved
  `PostProcessResult()` to `SassCompiler` derived class.

Next we need to stitch the decoded source-maps into normalizer to get
the correct paths in import scenarios.