### PR TITLE
Build: Removes exclusion that breaks jshint

### DIFF
--- a/BuildTasks/NodeInstaller.cs
+++ b/BuildTasks/NodeInstaller.cs
@@ -32,7 +32,6 @@ namespace WebEssentials.BuildTasks
             "Makefile.*",
             "Rakefile",
             "*.yml",
-            "test.*",
             "generate-*",
             "media",
             "images",


### PR DESCRIPTION
@madskristensen, this delta fixes the jshint dependency `shelljs` issue we discussed, where shelljs has a source file `shelljs/src/test.js` which is `require()`d.