### PR TITLE
 Bundle: Detach the event on change

### DIFF
--- a/EditorExtensions/Misc/Bundles/BundleFilesObserver.cs
+++ b/EditorExtensions/Misc/Bundles/BundleFilesObserver.cs
@@ -14,16 +14,18 @@ namespace MadsKristensen.EditorExtensions
         private IBundleDocument _document;
         private FileSystemWatcher _watcher;
         private FileSystemEventHandler _changeEvent;
-        private string[] _extensions = new[] { ".bundle", ".sprite" };
-        private readonly AsyncReaderWriterLock rwLock = new AsyncReaderWriterLock();
-        private static Dictionary<string, HashSet<Tuple<string, FileSystemWatcher>>> _watchedFiles = new Dictionary<string, HashSet<Tuple<string, FileSystemWatcher>>>();
+        private readonly string[] _extensions = { ".bundle", ".sprite" };
+        private readonly AsyncReaderWriterLock _rwLock = new AsyncReaderWriterLock();
+        private readonly static Dictionary<string, HashSet<Tuple<string, FileSystemWatcher>>> WatchedFiles = new Dictionary<string, HashSet<Tuple<string, FileSystemWatcher>>>();
 
         public void WatchFutureFiles(string path, string extension, Func<string, Task> callbackTask)
         {
-            _watcher = new FileSystemWatcher();
-            _watcher.Path = Path.GetDirectoryName(path);
-            _watcher.Filter = extension;
-            _watcher.IncludeSubdirectories = true;
+            _watcher = new FileSystemWatcher
+            {
+                Path = Path.GetDirectoryName(path),
+                Filter = extension,
+                IncludeSubdirectories = true
+            };
 
             _watcher.Created += async (_, __) => await callbackTask(__.FullPath);
 
@@ -39,20 +41,22 @@ namespace MadsKristensen.EditorExtensions
             if (!File.Exists(fileName))
                 return;
 
-            _watcher = new FileSystemWatcher();
-            _watcher.Path = Path.GetDirectoryName(fileName);
-            _watcher.Filter = Path.GetFileName(fileName);
-            //_watcher.NotifyFilter = NotifyFilters.Attributes | NotifyFilters.LastWrite | NotifyFilters.Size;
-            _watcher.NotifyFilter = NotifyFilters.Attributes |
-                                    NotifyFilters.CreationTime |
-                                    NotifyFilters.FileName |
-                                    NotifyFilters.LastAccess |
-                                    NotifyFilters.LastWrite |
-                                    NotifyFilters.Size;
-
-            using (await rwLock.ReadLockAsync())
+            _watcher = new FileSystemWatcher
             {
-                if (_watchedFiles.ContainsKey(_bundleFileName) && _watchedFiles[_bundleFileName].Any(s => s.Item1.Equals(fileName, StringComparison.OrdinalIgnoreCase)))
+                Path = Path.GetDirectoryName(fileName),
+                Filter = Path.GetFileName(fileName),
+                //_watcher.NotifyFilter = NotifyFilters.Attributes | NotifyFilters.LastWrite | NotifyFilters.Size;
+                NotifyFilter = NotifyFilters.Attributes |
+                               NotifyFilters.CreationTime |
+                               NotifyFilters.FileName |
+                               NotifyFilters.LastAccess |
+                               NotifyFilters.LastWrite |
+                               NotifyFilters.Size
+            };
+
+            using (await _rwLock.ReadLockAsync())
+            {
+                if (WatchedFiles.ContainsKey(_bundleFileName) && WatchedFiles[_bundleFileName].Any(s => s.Item1.Equals(fileName, StringComparison.OrdinalIgnoreCase)))
                     return;
             }
 
@@ -66,12 +70,12 @@ namespace MadsKristensen.EditorExtensions
 
             _watcher.EnableRaisingEvents = true;
 
-            using (await rwLock.WriteLockAsync())
+            using (await _rwLock.WriteLockAsync())
             {
-                if (!_watchedFiles.ContainsKey(_bundleFileName))
-                    _watchedFiles.Add(_bundleFileName, new HashSet<Tuple<string, FileSystemWatcher>>());
+                if (!WatchedFiles.ContainsKey(_bundleFileName))
+                    WatchedFiles.Add(_bundleFileName, new HashSet<Tuple<string, FileSystemWatcher>>());
 
-                _watchedFiles[_bundleFileName].Add(new Tuple<string, FileSystemWatcher>(fileName, _watcher));
+                WatchedFiles[_bundleFileName].Add(new Tuple<string, FileSystemWatcher>(fileName, _watcher));
             }
         }
 
@@ -79,23 +83,23 @@ namespace MadsKristensen.EditorExtensions
         {
             Task.Run(async () =>
             {
-                using (await rwLock.ReadLockAsync())
+                using (await _rwLock.ReadLockAsync())
                 {
-                    if (!_watchedFiles.ContainsKey(renamedEventArgument.OldFullPath) ||
+                    if (!WatchedFiles.ContainsKey(renamedEventArgument.OldFullPath) ||
                         !renamedEventArgument.FullPath.StartsWith(ProjectHelpers.GetSolutionFolderPath(), StringComparison.OrdinalIgnoreCase))
                         return;
                 }
 
                 HashSet<Tuple<string, FileSystemWatcher>> oldValue;
 
-                using (await rwLock.ReadLockAsync())
+                using (await _rwLock.ReadLockAsync())
                 {
-                    oldValue = _watchedFiles[renamedEventArgument.OldFullPath];
+                    oldValue = WatchedFiles[renamedEventArgument.OldFullPath];
                 }
 
-                using (await rwLock.WriteLockAsync())
+                using (await _rwLock.WriteLockAsync())
                 {
-                    _watchedFiles.Remove(renamedEventArgument.OldFullPath);
+                    WatchedFiles.Remove(renamedEventArgument.OldFullPath);
                 }
 
                 _document = await _document.LoadFromFile(renamedEventArgument.FullPath);
@@ -130,16 +134,17 @@ namespace MadsKristensen.EditorExtensions
 
                 IEnumerable<Tuple<string, FileSystemWatcher>> tuples;
 
-                using (await rwLock.ReadLockAsync())
+                using (await _rwLock.ReadLockAsync())
                 {
-                    tuples = _watchedFiles[_bundleFileName].Where(x => !_extensions.Any(e => x.Item1.EndsWith(e)) && !_document.BundleAssets.Contains(x.Item1, StringComparer.OrdinalIgnoreCase));
+                    tuples = WatchedFiles[_bundleFileName].Where(x => !_extensions.Any(e => x.Item1.EndsWith(e)) && !_document.BundleAssets.Contains(x.Item1, StringComparer.OrdinalIgnoreCase));
                 }
 
-                using (await rwLock.WriteLockAsync())
+                using (await _rwLock.WriteLockAsync())
                 {
-                    StopMonitoring(tuples);
+                    IList<Tuple<string, FileSystemWatcher>> enumerable = tuples as IList<Tuple<string, FileSystemWatcher>> ?? tuples.ToList();
+                    StopMonitoring(enumerable);
 
-                    _watchedFiles[_bundleFileName].RemoveWhere(x => tuples.Contains(x));
+                    WatchedFiles[_bundleFileName].RemoveWhere(x => enumerable.Contains(x));
                 }
             }).Wait();
 
@@ -170,34 +175,35 @@ namespace MadsKristensen.EditorExtensions
                 if (File.Exists(fileName))
                     return;
 
-                using (await rwLock.ReadLockAsync())
+                using (await _rwLock.ReadLockAsync())
                 {
-                    if (!_watchedFiles.ContainsKey(fileName))
+                    if (!WatchedFiles.ContainsKey(fileName))
                         return;
                 }
 
                 bool isConstituent = !_extensions.Any(e => fileName.EndsWith(e, StringComparison.OrdinalIgnoreCase));
                 IEnumerable<Tuple<string, FileSystemWatcher>> tuples = null;
 
-                using (await rwLock.ReadLockAsync())
+                using (await _rwLock.ReadLockAsync())
                 {
                     tuples = !isConstituent ?
-                             _watchedFiles[_bundleFileName] :
-                             _watchedFiles.SelectMany(p => p.Value.Where(v => v.Item1.Equals(fileName, StringComparison.OrdinalIgnoreCase)));
+                             WatchedFiles[_bundleFileName] :
+                             WatchedFiles.SelectMany(p => p.Value.Where(v => v.Item1.Equals(fileName, StringComparison.OrdinalIgnoreCase)));
                 }
 
-                using (await rwLock.WriteLockAsync())
+                using (await _rwLock.WriteLockAsync())
                 {
-                    StopMonitoring(tuples);
+                    IEnumerable<Tuple<string, FileSystemWatcher>> enumerable = tuples as IList<Tuple<string, FileSystemWatcher>> ?? tuples.ToList();
+                    StopMonitoring(enumerable);
 
                     if (isConstituent)
                     {
-                        _watchedFiles[_bundleFileName].RemoveWhere(x => tuples.Contains(x));
+                        WatchedFiles[_bundleFileName].RemoveWhere(x => enumerable.Contains(x));
 
                         return;
                     }
 
-                    _watchedFiles.Remove(_bundleFileName);
+                    WatchedFiles.Remove(_bundleFileName);
                 }
 
                 _watcher.EnableRaisingEvents = false;


### PR DESCRIPTION
In #1918, the reported exception is a false-positive as the observer
was firing the change event twice. This fixes the root-cause of the
problem (instead of catching the exception in `CssUrlNormalizer.FixPath(_)`).

---

Also took some ReSharper suggestions.  

If required, I can squash those commits.

@SLaks, PTAL.