### PR TITLE
srv-less: Adds the missing rootpath option

### DIFF
--- a/EditorExtensions/Resources/server/services/srv-less.js
+++ b/EditorExtensions/Resources/server/services/srv-less.js
@@ -32,6 +32,7 @@ var handleLess = function (writer, params) {
             filename: params.sourceFileName,
             paths: [sourceDir],
             relativeUrls: params.relativeUrls !== undefined,
+            rootpath: path.dirname(path.relative(path.dirname(params.targetFileName), params.sourceFileName)).replace(/\\/g, '/') + "/",
             sourceMap: {
                 sourceMapFullFilename: mapFileName,
                 sourceMapURL: params.sourceMapURL !== undefined ? path.basename(mapFileName) : null,


### PR DESCRIPTION
This is for Less compiler can resolve the relative path.
I somehow forgot the incorporate this bit.. :disappointed:

Related discussion: less/less.js#2084
Fixes #1922.