### PR TITLE
node-services: Fixes a map content type bug

### DIFF
--- a/EditorExtensions/Resources/server/services/srv-autoprefixer.js
+++ b/EditorExtensions/Resources/server/services/srv-autoprefixer.js
@@ -1,6 +1,7 @@
 //#region Imports
 var autoprefixer = require("autoprefixer"),
-    fs = require("fs");
+    fs = require("fs"),
+    postcss = require('postcss');
 //#endregion
 
 //#region Process
@@ -9,7 +10,7 @@ var processAutoprefixer = function (cssContent, mapContent, browsers, sourceFile
 
     if (browsers !== undefined)
         try {
-            result = autoprefixer(browsers.split(",").map(function (s) { return s.trim(); }));
+            result = postcss([autoprefixer(browsers.split(",").map(function (s) { return s.trim(); }))]);
         } catch (e) {
             // Return same css and map back so compilers can continue.
             return {

--- a/EditorExtensions/Resources/server/services/srv-less.js
+++ b/EditorExtensions/Resources/server/services/srv-less.js
@@ -71,7 +71,7 @@ var handleLess = function (writer, params) {
                     }
 
                     css = autoprefixedOutput.css;
-                    map = autoprefixedOutput.map;
+                    map = JSON.stringify(autoprefixedOutput.map);
                 }
 
                 if (params.rtlcss !== undefined) {
@@ -91,7 +91,7 @@ var handleLess = function (writer, params) {
                             RtlMapFileName: rtlMapFileName,
                             Remarks: "Successful!",
                             Content: css,
-                            Map: JSON.stringify(map),
+                            Map: map,
                             RtlContent: rtlResult.css,
                             RtlMap: JSON.stringify(rtlResult.map)
                         }));
@@ -107,7 +107,7 @@ var handleLess = function (writer, params) {
                         MapFileName: params.mapFileName,
                         Remarks: "Successful!",
                         Content: css,
-                        Map: JSON.stringify(map)
+                        Map: map
                     }));
                 }
 


### PR DESCRIPTION
This fixes two things:

* Deprecated warning for autoprefixer:

  >  Autoprefixer's process() method is deprecated and will removed in next major release. 
Use postcss([autoprefixer]).process() instead

* Stringify Map file when processed from autoprefixer; so when `autoprefixer` and `rtlcss` are `True`, it should not re-stringify the map output.
