### PR TITLE
Use a baseUrl setting to reference original JS files inside a map file.

### DIFF
--- a/EditorExtensions/Misc/Bundles/BundleGenerator.cs
+++ b/EditorExtensions/Misc/Bundles/BundleGenerator.cs
@@ -93,7 +93,7 @@ namespace MadsKristensen.EditorExtensions
 
                 if (extension.Equals(".js", StringComparison.OrdinalIgnoreCase) && WESettings.Instance.JavaScript.GenerateSourceMaps)
                 {
-                    sb.AppendLine("///#source 1 1 " + files[file]);
+                    sb.AppendLine("///#source 1 1 " + string.Format("{0}{1}", WESettings.Instance.JavaScript.BaseUrl, files[file]));
                 }
 
                 var source = await FileHelpers.ReadAllTextRetry(actualFile);

--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -369,6 +369,12 @@ namespace MadsKristensen.EditorExtensions.Settings
         [Description("Forces all rules to be terminated with semicolons when true.")]
         [DefaultValue(true)]
         public bool TermSemicolons { get; set; }
+
+		[Category("Bundle")]
+		[DisplayName("Custom base url for resources")]
+		[Description("Specifies a base path to be prepended in bundled .js, in case the assets are hosted from a virtual directory.")]
+		[DefaultValue("")]
+		public string BaseUrl { get; set; }
         #endregion
 
         [Category("Editor")]


### PR DESCRIPTION
I have added a parameter baseUrl to solution settings that is used when generating JavaScript map files, so the map file will point to the original JS files using this base url.