### PR TITLE
Add `PreserveCase` property to HTML minification settings

### DIFF
--- a/EditorExtensions/Misc/Minification/IFileMinifier.cs
+++ b/EditorExtensions/Misc/Minification/IFileMinifier.cs
@@ -68,6 +68,8 @@ namespace MadsKristensen.EditorExtensions.Optimization.Minification
             var weHtmlSettings = WESettings.Instance.Html;
             var settings = new HtmlMinificationSettings
             {
+                PreserveCase = weHtmlSettings.PreserveCase;
+
                 // Tags
                 RemoveOptionalEndTags = false,
                 //EmptyTagRenderMode = HtmlEmptyTagRenderMode.Slash,

--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -256,6 +256,12 @@ namespace MadsKristensen.EditorExtensions.Settings
         public bool MinifyKnockoutBindingExpressions { get; set; }
 
         [Category("Minification")]
+        [DisplayName("Preserve case of tag and attribute names")]
+        [Description("Preserve case of HTML tag and attribute names during minification.")]
+        [DefaultValue(false)]
+        public bool PreserveCase { get; set; }
+
+        [Category("Minification")]
         [DisplayName("Processable script types")]
         [Description(@"Specify comma-separated list of types of script tags, that are processed by minifier (e.g. ""text/html, text/ng-template"").")]
         [DefaultValue(null)]

--- a/EditorExtensions/WebEssentials2013.csproj
+++ b/EditorExtensions/WebEssentials2013.csproj
@@ -238,9 +238,9 @@
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="WebMarkupMin.Core, Version=0.9.12.0, Culture=neutral, PublicKeyToken=99472178d266584b, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\WebMarkupMin.Core.0.9.12\lib\net40\WebMarkupMin.Core.dll</HintPath>
+    <Reference Include="WebMarkupMin.Core, Version=1.1.0.0, Culture=neutral, PublicKeyToken=99472178d266584b, processorArchitecture=MSIL">
+      <HintPath>..\packages\WebMarkupMin.Core.1.1.0\lib\net40\WebMarkupMin.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="ZenCoding, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/EditorExtensions/packages.config
+++ b/EditorExtensions/packages.config
@@ -6,5 +6,5 @@
   <package id="Minimatch" version="1.1.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
   <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net451" />
-  <package id="WebMarkupMin.Core" version="0.9.12" targetFramework="net451" />
+  <package id="WebMarkupMin.Core" version="1.1.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
This property allows to preserve case of tag and attribute names during HTML minification (useful for Angular 2 templates).